### PR TITLE
Fix layout issue for the status indicators of Step 2 on Safari

### DIFF
--- a/src/pfs_target_uploader/widgets.py
+++ b/src/pfs_target_uploader/widgets.py
@@ -141,8 +141,8 @@ class StatusWidgets:
             self.status_vals,
             self.status_dups,
             ncols=4,
-            nrows=1,
-            # width=300,
+            nrows=2,
+            height=120,
         )
 
         """self.summary_nobj_L = pn.indicators.Number(
@@ -183,6 +183,7 @@ class StatusWidgets:
             # "# Status",
             self.status_grid,
             self.summary_table,
+            # height=400,
         )
 
     def reset(self):


### PR DESCRIPTION
When using Safari, the location of status indicators for Step 2 (validation) was strange. This commit fixes it by explictly set the height of the GridBox widget. I hope it is okay.