### PR TITLE
Strictly impose int64 for obj_id

### DIFF
--- a/src/pfs_target_uploader/utils.py
+++ b/src/pfs_target_uploader/utils.py
@@ -155,9 +155,22 @@ filter_names = [
 
 
 def load_input(byte_string, format="csv", dtype=target_datatype, logger=logger):
+    def convert_to_int64(value):
+        if isinstance(value, float):
+            raise ValueError(f"Invalid integer value: {value} (float)")
+        try:
+            return np.int64(value)
+        except ValueError:
+            raise ValueError(f"Invalid integer value: {value}")
+
     if format == "csv":
         try:
-            df_input = pd.read_csv(byte_string, encoding="utf8", dtype=dtype)
+            df_input = pd.read_csv(
+                byte_string,
+                encoding="utf8",
+                dtype=dtype,
+                converters={"obj_id": convert_to_int64},
+            )
             load_status = True
             load_error = None
         except ValueError as e:


### PR DESCRIPTION
When obj_id is a float value, it is automatically converted by pd.read_csv(). This commit raise an error when float value is found in the `ob_code` column.

(string value has already been considered in read_csv())