### PR TITLE
Reset FileInput instance when a session starts

### DIFF
--- a/src/pfs_target_uploader/pn_app.py
+++ b/src/pfs_target_uploader/pn_app.py
@@ -93,6 +93,8 @@ def target_uploader_app():
     panel_ppp = PPPresultWidgets()
     panel_submit_button = SubmitButtonWidgets()
 
+    panel_input.reset()
+
     button_set = [
         panel_input.file_input,
         panel_validate_button.validate,

--- a/src/pfs_target_uploader/widgets.py
+++ b/src/pfs_target_uploader/widgets.py
@@ -103,17 +103,29 @@ class FileInputWidgets(param.Parameterized):
         sizing_mode="stretch_width",
     )
     secret_token = None
+
     pane = pn.Column(
         """# Step 1:
 ## Select a target list ([example](doc/examples/example_targetlist.csv))""",
         file_input,
     )
 
+    # FIXME:
+    # - This watcher function does not work for browser engines other than Gecko.
+    #   I don't know how to fix it...
+    # - The function is called multiple times when selecting a file. I don't know why.
     @pn.depends("file_input.value", watch=True)
     def generate_secret_token(self):
         st = secrets.token_hex(8)
         logger.info(f"Secret Token Updated: {st}")
         self.secret_token = st
+
+    # NOTE: When I put the `file_input` in `__init__(self)`, the watcher does not work.
+    #       The reset function is a sort of a workaround.
+    def reset(self):
+        self.file_input.filename = None
+        self.file_input.mime_type = None
+        self.file_input.value = None
 
 
 class StatusWidgets:


### PR DESCRIPTION
Moritani-san detected a strange behavior that targets of a previous session appeared to be displayed in the list even when no file is selected in the FileInput widget.

It seems that the values are kept between sessions because the FileInput class does not have a constructor.

I added a reset function rather than adding a constructor because the watcher function for the update of the value does not seem to work when the file_input instance is created. The initial token is not generated as well.

I'm wondering if there are other ways to implement this with a constructor.

The issue that non-Gecko rendering engines does not work with the watcher function. I have no idea what to do at this moment. I'm asking questions in the Panel forum.