### PR TITLE
fix: Force to sleep for a shoft time for Tabulator

### DIFF
--- a/src/pfs_target_uploader/widgets.py
+++ b/src/pfs_target_uploader/widgets.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import secrets
+import time
 
 import numpy as np
 import pandas as pd
@@ -332,7 +333,9 @@ class TargetWidgets:
             tabulator_editors[c] = None
         # for some reason, it need to be reset once.
         self.table_all.value = pd.DataFrame()
+        time.sleep(0.1)
         self.table_all.value = df
+        time.sleep(0.2)
         self.table_all.editors = tabulator_editors
         self.table_all.visible = True
 


### PR DESCRIPTION
Sometimes the target list table fails to load data content after the validation. It looks that the error is raised when some operations (e.g., pressing the validation button again) are commanded before updating the DataFrame in the Tabulator widget for targets.

This commit forces to sleep for a short period (0.1 and 0.2 s) for these processes. I hope it fixes the issue.