### PR TITLE
correct documentation for hsc r and i filters

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,6 +1,16 @@
 # Welcome
 
-The [PFS Target Uploader](https://pfs-etc.naoj.hawaii.edu/uploader/) is a web app to validate and submit the target list supplied by users with an observing time estimate by a pointing simulation.
+The [PFS Target Uploader](https://pfs-etc.naoj.hawaii.edu/uploader/) is a web app to validate and submit the target list
+supplied by users with an observing time estimate by a pointing simulation.
+
+!!! info
+    **August 10, 2024 (HST)**
+
+    In the examples of [input target lists](inputs.md), column names for fluxes are found to be incorrect
+    for the initial version released together with S25A CfP on August 5, 2024 (HST).
+    The `r`- (`i`-) band filters for HSC need to be either `r_old_hsc` or `r2_hsc` (`i_old_hsc` or `i2_hsc`).
+    We have updated the examples with correct information for the correct examples.
+    Please see the [Filters section](inputs.md#filters) for the details.
 
 ## Table of Contents
 
@@ -83,3 +93,9 @@ graph TD
 ## Demo
 
 ![type:video](videos/demo_v2.mp4){: style='width: 100%'}
+
+## Last Update
+
+August 10, 2024 (HST)
+
+See the [Releases on GitHub repository](https://github.com/Subaru-PFS/spt_target_uploader/releases) for the details.

--- a/docs/docs/inputs.md
+++ b/docs/docs/inputs.md
@@ -119,25 +119,26 @@ Flux columns must conform to the following requirements.
 
 ✅ Good
 
-| ob_code | g_hsc | g_hsc_error | i_hsc | i_hsc_error | g_ps1 | g_ps1_error |
-|---------|-------|-------------|-------|-------------|-------|-------------|
-| 1       | 10000 | 100         |       |             |       |             |
-| 2       | 20000 | 200         | 20000 |             |       |             |
-| 3       |       |             |       |             | 30000 | 300         |
+| ob_code | g_hsc | g_hsc_error | i2_hsc | i2_hsc_error | g_ps1 | g_ps1_error |
+|---------|-------|-------------|--------|--------------|-------|-------------|
+| 1       | 10000 | 100         |        |              |       |             |
+| 2       | 20000 | 200         | 20000  |              |       |             |
+| 3       |       |             |        |              | 30000 | 300         |
 
 ⚠️ OK
 
 - For the `ob_code 3`, `g_hsc` will be used and `g_ps1` will be ignored.
 
-| ob_code | g_hsc | g_hsc_error | i_hsc | i_hsc_error | g_ps1 | g_ps1_error |
-|---------|-------|-------------|-------|-------------|-------|-------------|
-| 1       | 10000 | 100         |       |             |       |             |
-| 2       | 20000 | 200         | 20000 |             |       |             |
-| 3       | 35000 | 350         |       |             | 30000 | 300         |
+| ob_code | g_hsc | g_hsc_error | i2_hsc | i2_hsc_error | g_ps1 | g_ps1_error |
+|---------|-------|-------------|--------|--------------|-------|-------------|
+| 1       | 10000 | 100         |        |              |       |             |
+| 2       | 20000 | 200         | 20000  |              |       |             |
+| 3       | 35000 | 350         |        |              | 30000 | 300         |
 
 🚫 Bad
 
 - The `ob_code 1` does not have flux information at all.
+- The `i_hsc` must be either `i_old_hsc` or `i2_hsc`.
 
 | ob_code | g_hsc | g_hsc_error | i_hsc | i_hsc_error | g_ps1 | g_ps1_error |
 |---------|-------|-------------|-------|-------------|-------|-------------|


### PR DESCRIPTION
Documentation update:
- In the example, `i_hsc` must be either `i_old_hsc` or `i2_hsc` for the correct cases, not `i_hsc`. The correct exmples are fixed for them.