### PR TITLE
Set numpy version requirement to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "mkdocs>=1.4.3",
     "multiprocess>=0.70.15",
     "myst-parser>=2.0.0",
+    "numpy<2.0.0",
     "pandas>=2.0.3",
     "python-dotenv>=1.0.0",
     "scikit-learn>=1.3.0",

--- a/src/pfs_target_uploader/utils/ppp.py
+++ b/src/pfs_target_uploader/utils/ppp.py
@@ -1199,7 +1199,7 @@ def ppp_result(
             "Point_" + RESmode + "_" + str(count)
             for count in (np.arange(0, len(obj_allo), 1) + 1)
         ]
-        
+
         obj_allo1 = obj_allo1.group_by("ppc_code")
         obj_allo1.rename_column("tel_fiber_usage_frac", "Fiber usage fraction (%)")
         obj_allo2 = Table.to_pandas(obj_allo1)


### PR DESCRIPTION
Apparently, cobraOps still is not compatible to numpy 2.0