### PR TITLE
Enable to download ppc lists

### DIFF
--- a/src/pfs_target_uploader/pn_app.py
+++ b/src/pfs_target_uploader/pn_app.py
@@ -781,6 +781,13 @@ def list_files_app(use_panel_cli=False):
             if len(row_select) > 0:
                 tmpdir = os.path.join(config["OUTPUT_DIR"], "tmp")
                 filepath_zip = os.path.join(tmpdir, f"{prefix_}_selected.zip")
+                filepath_zip_href = os.path.join(
+                    tmpdir.replace(config["OUTPUT_DIR"], "data/", 1),
+                    f"{prefix_}_selected.zip",
+                ).replace("//", "/")
+                # print(f"{tmpdir=}")
+                # print(f"{filepath_zip=}")
+                # print(f"{filepath_zip_href=}")
 
                 if not os.path.exists(tmpdir):
                     logger.info(f"{tmpdir} not found. Creating...")
@@ -798,7 +805,8 @@ def list_files_app(use_panel_cli=False):
                 logger.info(f"Zipfile saved under {filepath_zip}")
             else:
                 filepath_zip = None
-            return filepath_zip
+                filepath_zip_href = None
+            return filepath_zip_href
 
         def download_select(event):
             filepath_zip = zip_select()

--- a/src/pfs_target_uploader/pn_app.py
+++ b/src/pfs_target_uploader/pn_app.py
@@ -13,9 +13,7 @@ from astropy.table import Table
 from dotenv import dotenv_values
 from loguru import logger
 
-from io import BytesIO
 from zipfile import ZipFile
-import time
 
 from .utils.io import load_file_properties, load_input
 from .utils.mail import send_email

--- a/src/pfs_target_uploader/pn_app.py
+++ b/src/pfs_target_uploader/pn_app.py
@@ -13,6 +13,10 @@ from astropy.table import Table
 from dotenv import dotenv_values
 from loguru import logger
 
+from io import BytesIO
+from zipfile import ZipFile
+import time
+
 from .utils.io import load_file_properties, load_input
 from .utils.mail import send_email
 from .utils.ppp import ppp_result_reproduce
@@ -653,25 +657,29 @@ def list_files_app(use_panel_cli=False):
         start=np.floor(df_files_tgt_psl["n_obj"].min() / 10) * 10,
         end=np.ceil(df_files_tgt_psl["n_obj"].max() / 10) * 10,
         step=1,
+        width=350,
     )
     slider_fiberhour = pn.widgets.EditableRangeSlider(
         name="Fiberhour (h)",
         start=np.floor(df_files_tgt_psl["Exptime_tgt (FH)"].min()),
         end=np.ceil(df_files_tgt_psl["Exptime_tgt (FH)"].max()),
         step=1,
+        width=350,
     )
 
     slider_rot_l = pn.widgets.EditableRangeSlider(
-        name="ROT (low, h)",
+        name="ROT_low (h)",
         start=np.floor(df_files_tgt_psl["Time_tot_L (h)"].min()),
         end=np.ceil(df_files_tgt_psl["Time_tot_L (h)"].max()),
         step=1,
+        width=350,
     )
     slider_rot_m = pn.widgets.EditableRangeSlider(
-        name="ROT (medium, h)",
+        name="ROT_med (h)",
         start=np.floor(df_files_tgt_psl["Time_tot_M (h)"].min()),
         end=np.ceil(df_files_tgt_psl["Time_tot_M (h)"].max()),
         step=1,
+        width=350,
     )
 
     # Target & psl summary table
@@ -691,7 +699,7 @@ def list_files_app(use_panel_cli=False):
 
         _hidden_columns = list(
             set(list(_df_files_tgt_psl.columns)) - set(column_checkbox_)
-        )
+        ) + ["index"]
 
         _table_files_tgt_psl = pn.widgets.Tabulator(
             _df_files_tgt_psl,
@@ -711,8 +719,15 @@ def list_files_app(use_panel_cli=False):
             disabled=True,
             selection=[],
             selectable="checkbox",
+            formatters={"TAC_done": {"type": "tickCross"}},
+            text_align={
+                "TAC_done": "center",
+                "observation_type": "center",
+                "pointing_status": "center",
+            },
         )
 
+        """
         dirs = glob.glob(os.path.join(config["OUTPUT_DIR"], "????/??/*/*"))
         upload_id_tacFin = [
             tt[tt.find("TAC_psl_") + 8 : tt.rfind(".ecsv")]
@@ -723,6 +738,7 @@ def list_files_app(use_panel_cli=False):
             np.in1d(_table_files_tgt_psl.value["Upload ID"], upload_id_tacFin) == True
         )[0]
         _table_files_tgt_psl.selection = [int(tt) for tt in row_tacFin]
+        #"""
 
         _table_files_tgt_psl.add_filter(slider_nobj, "n_obj")
         _table_files_tgt_psl.add_filter(slider_fiberhour, "t_exp")
@@ -739,14 +755,56 @@ def list_files_app(use_panel_cli=False):
 
         def open_panel_download(event):
             if event.column == "download":
-                href = df_files_tgt_psl["fullpath_tgt"][event.row]
+                href_tgt = df_files_tgt_psl["fullpath_tgt"][event.row]
+                href_ppc = df_files_tgt_psl["fullpath_ppc"][event.row]
                 # need to fix the path for the download
-                href_mod = href.replace(config["OUTPUT_DIR"], "data", 1)
-                logger.info(f"{href=}")
-                logger.info(f"{href_mod=}")
+                href_mod_tgt = href_tgt.replace(config["OUTPUT_DIR"], "data", 1)
+                href_mod_ppc = href_ppc.replace(config["OUTPUT_DIR"], "data", 1)
+                logger.info(f"{href_tgt=}")
+                logger.info(f"{href_mod_tgt=}")
                 # c.f. https://www.w3schools.com/jsref/met_win_open.asp
-                script = f"window.open('{href_mod}', '_blank')"
-                execute_javascript(script)
+                script_tgt = f"window.open('{href_mod_tgt}', '_blank')"
+                script_ppc = f"window.open('{href_mod_ppc}', '_blank')"
+                execute_javascript(script_tgt)
+                execute_javascript(script_ppc)
+
+        def zip_select():
+            if download_group.value == "Target":
+                column_ = "fullpath_tgt"
+                prefix_ = "target"
+            elif download_group.value == "PPC":
+                column_ = "fullpath_ppc"
+                prefix_ = "ppc"
+            elif download_group.value == "PPC (after allocation)":
+                column_ = "fullpath_ppc_tac"
+                prefix_ = "ppc_tac"
+
+            row_select = _table_files_tgt_psl.selection
+
+            if len(row_select) > 0:
+                filepath_zip = f"{config['OUTPUT_DIR']}/temp/{prefix_}_selected.zip"
+
+                with ZipFile(filepath_zip, "w") as zipfile:
+                    for filepath_ in _table_files_tgt_psl.value[column_][row_select]:
+                        if filepath_ is not None:
+                            zipfile.write(filepath_, os.path.basename(filepath_))
+                zipfile.close()
+                logger.info(f"Zipfile saved under {filepath_zip}")
+            else:
+                filepath_zip = None
+            return filepath_zip
+
+        def download_select(event):
+            filepath_zip = zip_select()
+            if filepath_zip is None:
+                pn.state.notifications.error(
+                    f"Can not download due to no selected program.",
+                    duration=5000,
+                )
+            else:
+                script_list_select = f"window.open('{filepath_zip}')"
+                execute_javascript(script_list_select)
+                logger.info(f"{filepath_zip} downloaded")
 
         def open_panel_magnify(event):
             row_target = event.row
@@ -800,13 +858,12 @@ def list_files_app(use_panel_cli=False):
                 path_t = path_t_server.replace(config["OUTPUT_DIR"], "data", 1)
                 tac_ppc_list_file = f"{path_t}/TAC_ppc_{u_id}.ecsv"
 
-                logger.info(f"{_table_files_tgt_psl.selection}")
                 logger.info(f"{row_target=}")
-                if row_target in _table_files_tgt_psl.selection:
+                if _df_files_tgt_psl["TAC_done"][row_target]:
                     # make the ppc list downloadable
                     fd_link = pn.pane.Markdown(
-                        f"<font size=4>(<a href={tac_ppc_list_file} target='_blank'>Download the PPC list</a>)</font>",
-                        margin=(0, 0, 0, -15),
+                        f"<font size=4>(<a href={tac_ppc_list_file} target='_blank'>Download the allocated PPC list</a>)</font>",
+                        margin=(0, 0, 0, -40),
                     )
                     logger.info("TAC PPC list is already available.")
 
@@ -824,9 +881,10 @@ def list_files_app(use_panel_cli=False):
                         f"File TAC_ppc_{u_id}.ecsv is saved under {path_t_server}."
                     )
                     # make the ppc list downloadable
-                    fd_link.object = f"<font size=4>(<a href={tac_ppc_list_file} target='_blank'>Download the PPC list</a>)</font>"
+                    fd_link.object = f"<font size=4>(<a href={tac_ppc_list_file} target='_blank'>Download the allocated PPC list</a>)</font>"
 
-                    Table.from_pandas(p_result_tab.value).write(
+                    tb_tac_psl_t = Table.from_pandas(p_result_tab.value)
+                    tb_tac_psl_t.write(
                         f"{path_t_server}/TAC_psl_{u_id}.ecsv",
                         format="ascii.ecsv",
                         delimiter=",",
@@ -837,13 +895,8 @@ def list_files_app(use_panel_cli=False):
                     )
 
                     # update tac allocation in program info tab
-                    dirs = glob.glob(os.path.join(config["OUTPUT_DIR"], "????/??/*/*"))
-                    path_ = [path_t for path_t in dirs if "TAC_psl_" + u_id in path_t][
-                        0
-                    ]
-                    tb_tac_psl_t = Table.read(path_)
-
                     if sum(tb_tac_psl_t["resolution"] == "low") > 0:
+                        _df_files_tgt_psl["TAC_done"][row_target] = True
                         _df_files_tgt_psl["TAC_FH_L"][row_target] = tb_tac_psl_t[
                             "Texp (fiberhour)"
                         ][tb_tac_psl_t["resolution"] == "low"]
@@ -855,6 +908,7 @@ def list_files_app(use_panel_cli=False):
                         ][tb_tac_psl_t["resolution"] == "low"]
 
                     if sum(tb_tac_psl_t["resolution"] == "medium") > 0:
+                        _df_files_tgt_psl["TAC_done"][row_target] = True
                         _df_files_tgt_psl["TAC_FH_M"][row_target] = tb_tac_psl_t[
                             "Texp (fiberhour)"
                         ][tb_tac_psl_t["resolution"] == "medium"]
@@ -867,32 +921,18 @@ def list_files_app(use_panel_cli=False):
 
                     _table_files_tgt_psl.value = _df_files_tgt_psl
 
-                    # select rows which complete the tac allocation
-                    upload_id_tacFin = [
-                        tt[tt.find("TAC_psl_") + 8 : tt.rfind(".ecsv")]
-                        for tt in dirs
-                        if "TAC_psl_" in tt
-                    ]
-
-                    row_tacFin = np.where(
-                        np.in1d(
-                            _table_files_tgt_psl.value["Upload ID"], upload_id_tacFin
-                        )
-                        == True
-                    )[0]
-                    _table_files_tgt_psl.selection = [int(tt) for tt in row_tacFin]
-
                     # update tac allocation summary
                     tac_summary.object = (
-                        "<font size=5>Summary of Tac allocation:</font>\n"
+                        "<font size=5>Summary of TAC allocation:</font>\n"
+                        f"<font size=4> - N (allocated programs): <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_done']):.0f}**</span></font>\n"
                         "<font size=4> - Low-res mode: </font>\n"
-                        f"<font size=4> **FH** allocated= <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_FH_L']):.2f}**</span></font>\n"
-                        f"<font size=4> **Nppc** allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_nppc_L']):.0f}**</span> </font>\n"
-                        f"<font size=4> **ROT** (h) allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_ROT_L']):.2f}**</span> </font>\n"
+                        f"<font size=4>&emsp;**FH** allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_FH_L']):.2f}**</span></font>\n"
+                        f"<font size=4>&emsp;**Nppc** allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_nppc_L']):.0f}**</span> </font>\n"
+                        f"<font size=4>&emsp;**ROT** (h) allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_ROT_L']):.2f}**</span> </font>\n"
                         "<font size=4> - Medium-res mode: </font>\n"
-                        f"<font size=4> **FH** allocated= <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_FH_M']):.2f}**</span></font>\n"
-                        f"<font size=4> **Nppc** allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_nppc_M']):.0f}**</span> </font>\n"
-                        f"<font size=4> **ROT** (h) allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_ROT_M']):.2f}**</span> </font>\n"
+                        f"<font size=4>&emsp;**FH** allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_FH_M']):.2f}**</span></font>\n"
+                        f"<font size=4>&emsp;**Nppc** allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_nppc_M']):.0f}**</span> </font>\n"
+                        f"<font size=4>&emsp;**ROT** (h) allocated = <span style='color:tomato'>**{sum(_df_files_tgt_psl['TAC_ROT_M']):.2f}**</span> </font>\n"
                     )
                     pn.state.notifications.info(
                         "TAC allocation is made for the program and a new PPC list is saved.",
@@ -919,10 +959,10 @@ def list_files_app(use_panel_cli=False):
                         margin=(20, 0, 0, 0),
                     )
 
-                    if row_target not in _table_files_tgt_psl.selection:
+                    if not _df_files_tgt_psl["TAC_done"][row_target]:
                         fd_link = pn.pane.Markdown(
-                            "<font size=4>(Download the PPC list)</font>",
-                            margin=(0, 0, 0, -15),
+                            "<font size=4>(Download the allocated PPC list)</font>",
+                            margin=(0, 0, 0, -40),
                         )
 
                     fd_success.on_click(tab_ppc_save)
@@ -951,6 +991,7 @@ def list_files_app(use_panel_cli=False):
 
         _table_files_tgt_psl.on_click(open_panel_magnify)
         _table_files_tgt_psl.on_click(open_panel_download)
+        download_selection.on_click(download_select)
 
         return _table_files_tgt_psl
 
@@ -958,6 +999,7 @@ def list_files_app(use_panel_cli=False):
         name=" ",
         value=[
             "Upload ID",
+            "TAC_done",
             "n_obj",
             "Time_tot_L (h)",
             "Time_tot_M (h)",
@@ -973,17 +1015,48 @@ def list_files_app(use_panel_cli=False):
 
     table_files_tgt_psl = pn.bind(Table_files_tgt_psl, column_checkbox)
 
+    # download buttons
+    download_selection = pn.widgets.Button(
+        name="Download all the selected programs",
+        icon="download",
+        button_type="primary",
+        stylesheets=[
+            """
+            .bk-btn {
+                color: var(--success-text-color) !important;
+                background-color: #C7E2D6 !important;
+                border-color: var(--success-border-subtle) !important;
+                border-width: 1px;
+                font-weight: bold !important;
+                font-size: 140% !important;
+                // color: #145B33;
+                // background-color: #eaf4fc;
+                // background-color: var(--success-bg-color);
+                // border-color: #008899;
+            }
+        """
+        ],
+        width=300,
+    )
+    download_group = pn.widgets.RadioBoxGroup(
+        value="Target",
+        options=["Target", "PPC", "PPC (after allocation)"],
+        inline=True,
+        align="center",
+    )
+
     # summary of tac allocation
     tac_summary = pn.pane.Markdown(
-        "<font size=5>Summary of Tac allocation:</font>\n"
+        "<font size=5>Summary of TAC allocation:</font>\n"
+        f"<font size=4> - N (allocated programs): <span style='color:tomato'>**{sum((df_files_tgt_psl['TAC_nppc_L']>0) | (df_files_tgt_psl['TAC_nppc_M']>0)):.0f}**</span></font>\n"
         "<font size=4> - Low-res mode: </font>\n"
-        f"<font size=4> FH allocated= <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_FH_L']):.2f}**</span></font>\n"
-        f"<font size=4> Nppc allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_nppc_L']):.0f}**</span> </font>\n"
-        f"<font size=4> ROT (h) allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_ROT_L']):.2f}**</span> </font>\n"
+        f"<font size=4>&emsp;FH allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_FH_L']):.2f}**</span></font>\n"
+        f"<font size=4>&emsp;Nppc allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_nppc_L']):.0f}**</span> </font>\n"
+        f"<font size=4>&emsp;ROT (h) allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_ROT_L']):.2f}**</span> </font>\n"
         "<font size=4> - Medium-res mode: </font>\n"
-        f"<font size=4> FH allocated= <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_FH_M']):.2f}**</span></font>\n"
-        f"<font size=4> Nppc allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_nppc_M']):.0f}**</span> </font>\n"
-        f"<font size=4> ROT (h) allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_ROT_M']):.2f}**</span> </font>\n"
+        f"<font size=4>&emsp;FH allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_FH_M']):.2f}**</span></font>\n"
+        f"<font size=4>&emsp;Nppc allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_nppc_M']):.0f}**</span> </font>\n"
+        f"<font size=4>&emsp;ROT (h) allocated = <span style='color:tomato'>**{sum(df_files_tgt_psl['TAC_ROT_M']):.2f}**</span> </font>\n"
     )
 
     # Details of PPC
@@ -994,11 +1067,6 @@ def list_files_app(use_panel_cli=False):
 
     sidebar_column = pn.Column(
         psl_info,
-        pn.pane.Markdown("<font size=4> Select the proposals to show:</font>"),
-        slider_nobj,
-        slider_fiberhour,
-        slider_rot_l,
-        slider_rot_m,
         tac_summary,
     )
 
@@ -1011,6 +1079,18 @@ def list_files_app(use_panel_cli=False):
                     height=20,
                 ),
                 column_checkbox,
+                pn.pane.Markdown(
+                    "<font size=4> Select the proposals to show:</font>",
+                    height=35,
+                ),
+                pn.Row(
+                    slider_nobj,
+                    slider_fiberhour,
+                    slider_rot_l,
+                    slider_rot_m,
+                    height=60,
+                ),
+                pn.Row(download_selection, download_group),
                 table_files_tgt_psl,
                 js_panel,
             ),

--- a/src/pfs_target_uploader/utils/io.py
+++ b/src/pfs_target_uploader/utils/io.py
@@ -365,6 +365,8 @@ def load_file_properties(datadir, ext="ecsv", n_uid=16):
     links = np.full(n_files, None, dtype=object)
 
     fullpath_target = np.full(n_files, None, dtype=object)
+    fullpath_ppc = np.full(n_files, None, dtype=object)
+    fullpath_ppc_tac = np.full(n_files, None, dtype=object)
     fullpath_psl = np.full(n_files, None, dtype=object)
 
     exp_sci_l = np.zeros(n_files, dtype=float)
@@ -373,6 +375,7 @@ def load_file_properties(datadir, ext="ecsv", n_uid=16):
     exp_sci_fh_m = np.zeros(n_files, dtype=float)
     tot_time_l = np.zeros(n_files, dtype=float)
     tot_time_m = np.zeros(n_files, dtype=float)
+    tac_done = np.full(n_files, False, dtype=bool)
     tac_fh_l = np.zeros(n_files, dtype=float)
     tac_fh_m = np.zeros(n_files, dtype=float)
     tac_nppc_l = np.zeros(n_files, dtype=int)
@@ -387,8 +390,10 @@ def load_file_properties(datadir, ext="ecsv", n_uid=16):
         uid = d[-n_uid:]
         if ext == "ecsv":
             f_target = os.path.join(d, f"target_{uid}.{ext}")
+            f_ppc = os.path.join(d, f"ppc_{uid}.{ext}")
             f_psl = os.path.join(d, f"psl_{uid}.{ext}")
             f_tac = os.path.join(d, f"TAC_psl_{uid}.{ext}")
+            f_tac_ppc = os.path.join(d, f"TAC_ppc_{uid}.{ext}")
 
             try:
                 tb_target = Table.read(f_target)
@@ -405,10 +410,15 @@ def load_file_properties(datadir, ext="ecsv", n_uid=16):
             except FileNotFoundError:
                 tb_tac = Table()
 
+            if len(tb_tac) > 0:
+                tac_done[i] = True
+                fullpath_ppc_tac[i] = f_tac_ppc
+
             filesizes[i] = (os.path.getsize(f_target) * u.byte).to(u.kbyte).value
             # links[i] = f"<a href='{f_target}'><i class='fa-solid fa-download'></i></a>"
 
             fullpath_target[i] = f_target
+            fullpath_ppc[i] = f_ppc
             fullpath_psl[i] = f_psl
 
             try:
@@ -492,6 +502,7 @@ def load_file_properties(datadir, ext="ecsv", n_uid=16):
     df_psl_tgt = pd.DataFrame(
         {
             "Upload ID": upload_ids,
+            "TAC_done": tac_done,
             "n_obj": n_obj,
             "Exptime_tgt (FH)": t_exp,
             "Exptime_sci_L (h)": exp_sci_l,
@@ -510,6 +521,8 @@ def load_file_properties(datadir, ext="ecsv", n_uid=16):
             "filesize": filesizes,
             "timestamp": timestamps,
             "fullpath_tgt": fullpath_target,
+            "fullpath_ppc": fullpath_ppc,
+            "fullpath_ppc_tac": fullpath_ppc_tac,
             "fullpath_psl": fullpath_psl,
             "single_exptime": single_exptime,
             "observation_type": observation_type,

--- a/src/pfs_target_uploader/utils/ppp.py
+++ b/src/pfs_target_uploader/utils/ppp.py
@@ -1214,7 +1214,7 @@ def ppp_result(
 
         #obj_allo1 = obj_allo1.group_by("ppc_code")
         obj_allo1.rename_column("tel_fiber_usage_frac", "Fiber usage fraction (%)")
-        obj_allo2 = Table.to_pandas(obj_allo1)
+        obj_allo2 = Table.to_pandas(obj_allo1)        
         uS_ = Table.to_pandas(uS)
 
         # add a column to indicate the color for the scatter plot


### PR DESCRIPTION
Major:
1. clicking the “download” button on any rows of “Program info” table will download the full target&ppc lists (user can save/ignore either one in the popup window);
2. clicking the “download all the selected programs” button on the “Program info” tab can download target/ppc/tac_ppc lists for all selected programs;
3. for each program, the allocated ppc list can be downloaded after clicking the “Time allocated” button on the “PPC details” tab

others:
1. move sliders to the "program info" tab (not sure if it is better or worse...)
2. add a boolean column to "program info" table to show whether the time allocation has been done for the program

I tested it using chrome, firefox & safari. Firefox and safari work ok, but chrome seems to have some problems with downloading the overwritten files (clicking any "download" button after overwritting the related files can not link to the latest files).. -- not sure how to solve it..