### PR TITLE
Enable to use a SQLite3 database to track the already-issued upload_id

### DIFF
--- a/src/pfs_target_uploader/utils/db.py
+++ b/src/pfs_target_uploader/utils/db.py
@@ -1,0 +1,49 @@
+import sqlite3
+from contextlib import closing
+
+import pandas as pd
+from loguru import logger
+
+
+def create_uid_db(db_path):
+    """
+    Create a SQLite database with a table for upload IDs if it does not exist.
+    Parameters
+    ----------
+    db_path : str
+        The file path to the SQLite database.
+    Notes
+    -----
+    This function creates a table named `upload_id` with a single column `upload_id` of type TEXT.
+    If the table already exists, it will not be recreated.
+    Here, no UNIQUE constraint is added to the `upload_id` column, so duplicate entries can happen.
+    """
+    with closing(sqlite3.connect(db_path)) as conn:
+        with closing(conn.cursor()) as cur:
+            cur.execute("CREATE TABLE IF NOT EXISTS upload_id (upload_id TEXT)")
+            conn.commit()
+
+
+def bulk_insert_uid_db(df, db_path):
+    logger.info(f"Inserting {df.shape[0]} upload IDs to the database.")
+    with closing(sqlite3.connect(db_path)) as conn:
+        with closing(conn.cursor()) as cur:
+            cur.executemany(
+                "INSERT INTO upload_id VALUES (?)", [(x,) for x in df["upload_id"]]
+            )
+            conn.commit()
+
+
+def single_insert_uid_db(upload_id, db_path):
+    logger.info(f"Inserting a new upload ID to the database: {upload_id}")
+    with closing(sqlite3.connect(db_path)) as conn:
+        with closing(conn.cursor()) as cur:
+            cur.execute("INSERT INTO upload_id (upload_id) VALUES (?)", (upload_id,))
+            conn.commit()
+
+
+def upload_id_exists(upload_id, db_path):
+    with closing(sqlite3.connect(db_path)) as conn:
+        df = pd.read_sql_query("SELECT upload_id FROM upload_id", conn)
+
+    return upload_id in df["upload_id"].values

--- a/src/pfs_target_uploader/utils/session.py
+++ b/src/pfs_target_uploader/utils/session.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import glob
+import os
+import secrets
+
+from loguru import logger
+
+from .db import upload_id_exists
+
+
+def assign_secret_token(db_path=None, output_dir=None, use_db=True, nbytes=8):
+
+    st = secrets.token_hex(nbytes)
+
+    logger.info("Checking the uniqueness of the upload ID.")
+
+    while True:
+        if use_db:
+            if upload_id_exists(st, db_path):
+                logger.warning(
+                    f"Upload ID {st} already exists. Regenerating a new one."
+                )
+                st = secrets.token_hex(nbytes)
+            else:
+                break
+        else:
+            d = glob.glob(os.path.join(output_dir, f"????/??/????????-??????-{st}"))
+            if len(d) > 0:
+                logger.warning(
+                    f"Upload ID {st} already exists. Regenerating a new one."
+                )
+                st = secrets.token_hex(nbytes)
+            else:
+                break
+    logger.info(f"Assigning a new secret token as an upload_id: {st}")
+
+    return st

--- a/src/pfs_target_uploader/widgets/FileInputWidgets.py
+++ b/src/pfs_target_uploader/widgets/FileInputWidgets.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from ..utils.checker import validate_input
 from ..utils.io import load_input
+from ..utils.session import assign_secret_token
 
 
 class FileInputWidgets(param.Parameterized):
@@ -30,6 +31,9 @@ class FileInputWidgets(param.Parameterized):
 
         # hex string to be used as an upload ID
         self.secret_token = None
+        self.db_path = None
+        self.output_dir = None
+        self.use_db = True
 
         self.pane = pn.Column(
             pn.Row(
@@ -61,11 +65,6 @@ class FileInputWidgets(param.Parameterized):
         self.file_input.mime_type = None
         self.file_input.value = None
 
-    def assign_secret_token(self, nbytes=8):
-        st = secrets.token_hex(nbytes)
-        self.secret_token = st
-        logger.info(f"Assigning a new secret token as an upload_id: {st}")
-
     def validate(self, date_begin=None, date_end=None, warn_threshold=100000):
         t_start = time.time()
         if date_begin >= date_end:
@@ -81,7 +80,9 @@ class FileInputWidgets(param.Parameterized):
             or (self.file_input.mime_type != self.previous_mime_type)
         ):
 
-            self.assign_secret_token()
+            self.secret_token = assign_secret_token(
+                db_path=self.db_path, output_dir=self.output_dir, use_db=self.use_db
+            )
 
             logger.info("New file detected.")
             logger.info(f"    Upload ID updated: {self.secret_token}")


### PR DESCRIPTION
- By setting `UPLOADID_DB` (e.g., `upload_id.sqlite`) in `.env.shared`, One can use the SQLite3 database to check any duplicate upload_id issued in the past.
- If `UPLOADID_DB` is not set, simple look-up by `glob` is used.
- At the submission, the submitted `upload_id` is inserted to the db.
- CLI command `uid2sqlite` is added. One can input a csv file or directory path to be scanned to insert values to the db.