### PR TITLE
Add `clean_uid` command to the CLI tools

### DIFF
--- a/src/pfs_target_uploader/cli/cli_main.py
+++ b/src/pfs_target_uploader/cli/cli_main.py
@@ -4,6 +4,7 @@ import os
 import sys
 from datetime import date
 from enum import Enum
+from pathlib import Path
 from typing import Annotated, List
 
 import pandas as pd
@@ -13,7 +14,7 @@ from astropy.table import Table
 from loguru import logger
 
 from ..utils.checker import validate_input
-from ..utils.db import bulk_insert_uid_db, create_uid_db
+from ..utils.db import bulk_insert_uid_db, create_uid_db, remove_duplicate_uid_db
 from ..utils.io import load_input, upload_file
 from ..utils.ppp import PPPrunStart, ppp_result
 from ..widgets import StatusWidgets
@@ -438,3 +439,30 @@ def uid2sqlite(
 
     if not df_input.empty:
         bulk_insert_uid_db(df_input, os.path.join(output_dir, dbfile))
+
+
+@app.command(help="Remove duplicates from a SQLite database of upload_id")
+def clean_uid(
+    dbfile: Annotated[
+        Path,
+        typer.Argument(
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            help="Full path to the SQLite database file.",
+        ),
+    ],
+    backup: Annotated[
+        bool,
+        typer.Option(
+            help="Create a backup of the database before cleaning. Default is True."
+        ),
+    ] = True,
+    log_level: Annotated[
+        LogLevel, typer.Option(case_sensitive=False, help="Set the log level.")
+    ] = LogLevel.INFO,
+):
+    logger.remove(0)
+    logger.add(sys.stderr, level=log_level.value)
+
+    remove_duplicate_uid_db(dbfile, backup=backup)

--- a/src/pfs_target_uploader/cli/cli_main.py
+++ b/src/pfs_target_uploader/cli/cli_main.py
@@ -470,6 +470,12 @@ def clean_uid(
             help="Create a backup of the database before cleaning. Default is True."
         ),
     ] = True,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            help="Do not remove duplicates; just check the duplicates. Default is False."
+        ),
+    ] = False,
     log_level: Annotated[
         LogLevel, typer.Option(case_sensitive=False, help="Set the log level.")
     ] = LogLevel.INFO,
@@ -477,4 +483,4 @@ def clean_uid(
     logger.remove(0)
     logger.add(sys.stderr, level=log_level.value)
 
-    remove_duplicate_uid_db(dbfile, backup=backup)
+    remove_duplicate_uid_db(dbfile, backup=backup, dry_run=dry_run)

--- a/src/pfs_target_uploader/cli/cli_main.py
+++ b/src/pfs_target_uploader/cli/cli_main.py
@@ -411,12 +411,21 @@ def uid2sqlite(
             help="Directory to scan for the upload_id. Default is None (use input file)",
         ),
     ] = None,
+    remove_duplicates: Annotated[
+        bool,
+        typer.Option(
+            "--clean",
+            help="Remove duplicates from the database. Default is False.",
+        ),
+    ] = False,
     log_level: Annotated[
         LogLevel, typer.Option(case_sensitive=False, help="Set the log level.")
     ] = LogLevel.INFO,
 ):
     logger.remove(0)
     logger.add(sys.stderr, level=log_level.value)
+
+    db_path = os.path.join(output_dir, dbfile)
 
     if input_list is not None:
         df_input = pd.read_csv(input_list)
@@ -433,12 +442,15 @@ def uid2sqlite(
     if not os.path.exists(output_dir):
         raise FileNotFoundError(f"Output directory not found: {output_dir}")
 
-    if not os.path.exists(os.path.join(output_dir, dbfile)):
+    if not os.path.exists(db_path):
         logger.info(f"Creating a new SQLite database: {dbfile}")
-        create_uid_db(os.path.join(output_dir, dbfile))
+        create_uid_db(db_path)
 
     if not df_input.empty:
-        bulk_insert_uid_db(df_input, os.path.join(output_dir, dbfile))
+        bulk_insert_uid_db(df_input, db_path)
+
+    if remove_duplicates:
+        remove_duplicate_uid_db(db_path)
 
 
 @app.command(help="Remove duplicates from a SQLite database of upload_id")

--- a/src/pfs_target_uploader/utils/db.py
+++ b/src/pfs_target_uploader/utils/db.py
@@ -51,11 +51,20 @@ def upload_id_exists(upload_id, db_path):
     return upload_id in df["upload_id"].values
 
 
-def remove_duplicate_uid_db(db_path, backup=True):
+def remove_duplicate_uid_db(db_path, backup=True, dry_run=False):
     with closing(sqlite3.connect(db_path)) as conn:
         df = pd.read_sql_query("SELECT upload_id FROM upload_id", conn)
 
     if df["upload_id"].duplicated().any():
+        logger.info(f"{df['upload_id'].duplicated().sum()} duplicates found.")
+        logger.info(
+            f"Duplicate upload IDs: {df.loc[df['upload_id'].duplicated(), 'upload_id'].values}"
+        )
+        if dry_run:
+            logger.info(
+                "Dry run mode enabled. No changes will be made to the database."
+            )
+            return
         if backup:
             logger.info("Creating a backup of the database.")
             timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()

--- a/src/pfs_target_uploader/utils/db.py
+++ b/src/pfs_target_uploader/utils/db.py
@@ -1,3 +1,5 @@
+import datetime
+import shutil
 import sqlite3
 from contextlib import closing
 
@@ -47,3 +49,42 @@ def upload_id_exists(upload_id, db_path):
         df = pd.read_sql_query("SELECT upload_id FROM upload_id", conn)
 
     return upload_id in df["upload_id"].values
+
+
+def remove_duplicate_uid_db(db_path, backup=True):
+    with closing(sqlite3.connect(db_path)) as conn:
+        df = pd.read_sql_query("SELECT upload_id FROM upload_id", conn)
+
+    if df["upload_id"].duplicated().any():
+        if backup:
+            logger.info("Creating a backup of the database.")
+            timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
+            shutil.copyfile(db_path, f"{db_path}.bak-{timestamp}")
+            logger.info(f"Bakcup created: {db_path}.bak-{timestamp}")
+
+        with closing(sqlite3.connect(db_path)) as conn:
+            with closing(conn.cursor()) as cur:
+                # Step 1: Create a temporary table
+                cur.execute("CREATE TEMPORARY TABLE unique_upload_id (upload_id TEXT)")
+
+                # Step 2: Insert unique values into the temporary table
+                cur.execute(
+                    "INSERT INTO unique_upload_id SELECT DISTINCT upload_id FROM upload_id"
+                )
+
+                # Step 3: Delete all records from the original table
+                cur.execute("DELETE FROM upload_id")
+
+                # Step 4: Insert unique values back into the original table
+                cur.execute(
+                    "INSERT INTO upload_id SELECT upload_id FROM unique_upload_id"
+                )
+
+                # Step 5: Drop the temporary table
+                cur.execute("DROP TABLE unique_upload_id")
+
+                conn.commit()
+
+        logger.info("Duplicate upload IDs have been removed from the database.")
+    else:
+        logger.info("No duplicates found. No changes made to the database.")


### PR DESCRIPTION
- `clean_uid` command removes duplicate `upload_id`s in a sqlite3 database.
- It makes a backup of the db file by default. It can be turned off by specifying `--no-backup` option.