### PR TITLE
remove imaging dependencies from mkdocs-material

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -23,11 +23,11 @@ use_directory_urls: false
 
 plugins:
   - search
-  - social
   - mkdocs-video:
       is_video: True
       video_autoplay: False
       video_muted: False
+  # - social
 
 
 theme:
@@ -79,11 +79,11 @@ markdown_extensions:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
-extra:
-  social:
-    - icon: fontawesome/brands/github
-      link: https://github.com/Subaru-PFS/spt_target_uploader
-      name: PFS Target Uploader on GitHub
+# extra:
+#   social:
+#     - icon: fontawesome/brands/github
+#       link: https://github.com/Subaru-PFS/spt_target_uploader
+#       name: PFS Target Uploader on GitHub
 
 extra_css:
   - stylesheets/extra.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Target uploader for PFS openuse"
 authors = [{ name = "Masato Onodera", email = "monodera@naoj.org" }]
 dependencies = [
     "panel<1.7,>=1.6.0",
-    "numpy<2.0.0",
+    "numpy>=2.0",
     "astropy>=5.3.1",
     "astroplan>=0.9",
     "colorcet>=3.0.1",
@@ -18,7 +18,8 @@ dependencies = [
     "loguru>=0.7.2",
     "markdown-it-py>=3.0.0",
     "mkdocs-macros-plugin>=0.7.0",
-    "mkdocs-material[imaging]>=9.5.4",
+    # "mkdocs-material[imaging]>=9.5.4",
+    "mkdocs-material>=9.5.4",
     "mkdocs-video>=1.5.0",
     "mkdocs>=1.4.3",
     "multiprocess>=0.70.15",
@@ -33,7 +34,7 @@ dependencies = [
     "pybind11>=2.11.1",
     "setuptools>=68.2.2",
     "wheel>=0.41.2",
-    "qplan @ git+https://github.com/naojsoft/qplan.git@check-elevation",
+    "qplan @ git+https://github.com/naojsoft/qplan.git",
     "ets-fiber-assigner @ git+https://github.com/Subaru-PFS/ets_fiberalloc.git",
     "ics-cobraOps @ git+https://github.com/Subaru-PFS/ics_cobraOps.git",
     "pfs-utils @ git+https://github.com/Subaru-PFS/pfs_utils.git",

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,11 +23,11 @@ markdown-it-py>=3.0.0
 memray>=1.10.0
 mkdocs>=1.4.3
 mkdocs-macros-plugin>=0.7.0
-mkdocs-material[imaging]>=9.5.4
+mkdocs-material>=9.5.4
 mkdocs-video>=1.5.0
 multiprocess>=0.70.15
 myst-parser>=2.0.0
-numpy<2.0.0
+numpy>=2.0
 pandas>=2.0.3
 panel<1.7,>=1.6.0
 pfs-utils @ git+https://github.com/Subaru-PFS/pfs_utils.git
@@ -36,7 +36,7 @@ psutil>=6.0.0
 pybind11>=2.11.1
 pyinstrument>=4.6.0
 python-dotenv>=1.0.0
-qplan @ git+https://github.com/naojsoft/qplan.git@check-elevation
+qplan @ git+https://github.com/naojsoft/qplan.git
 ruff
 scikit-learn>=1.3.0
 seaborn>=0.12.2


### PR DESCRIPTION
There is an unsolvable dependency issue (pillow from ginga, qplan, mkdocs-material). To remove this, I removed the social card from the mkdocs configuration