### PR TITLE
use single_exptime for night-by-night observable time check

### DIFF
--- a/src/pfs_target_uploader/pn_app.py
+++ b/src/pfs_target_uploader/pn_app.py
@@ -317,6 +317,7 @@ def target_uploader_app(use_panel_cli=False):
             panel_input.validate,
             date_begin=panel_dates.date_begin.value,
             date_end=panel_dates.date_end.value,
+            single_exptime=panel_obs_type.single_exptime.value,
         )
 
         _toggle_widgets(widget_set, disabled=False)
@@ -386,6 +387,7 @@ def target_uploader_app(use_panel_cli=False):
             panel_input.validate,
             date_begin=panel_dates.date_begin.value,
             date_end=panel_dates.date_end.value,
+            single_exptime=panel_obs_type.single_exptime.value,
         )
         df_ppc = await asyncio.to_thread(panel_ppcinput.validate)
 

--- a/src/pfs_target_uploader/widgets/FileInputWidgets.py
+++ b/src/pfs_target_uploader/widgets/FileInputWidgets.py
@@ -65,7 +65,13 @@ class FileInputWidgets(param.Parameterized):
         self.file_input.mime_type = None
         self.file_input.value = None
 
-    def validate(self, date_begin=None, date_end=None, warn_threshold=100000):
+    def validate(
+        self,
+        date_begin=None,
+        date_end=None,
+        single_exptime=900.0,
+        warn_threshold=100000,
+    ):
         t_start = time.time()
         if date_begin >= date_end:
             pn.state.notifications.error(
@@ -129,7 +135,10 @@ class FileInputWidgets(param.Parameterized):
             return None, None, None
 
         validation_status, df_output = validate_input(
-            df_input.copy(deep=True), date_begin=date_begin, date_end=date_end
+            df_input.copy(deep=True),
+            date_begin=date_begin,
+            date_end=date_end,
+            single_exptime=single_exptime,
         )
         t_stop = time.time()
         logger.info(f"Validation finished in {t_stop - t_start:.2f} [s]")


### PR DESCRIPTION
Because of the API change on the per-night observable time calculation, it seems that the target observing time should be changed to the single exptime. Otherwise, either t_start or t_stop appear to be None.

This PR is to make a change to use single_exptime propagated from the input parameter. Here I set 900s as anyway we need 2x450s exposures in practice.