### PR TITLE
Fix pfs_utils version to w2025.31

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Target uploader for PFS openuse"
 authors = [{ name = "Masato Onodera", email = "monodera@naoj.org" }]
 dependencies = [
     "panel<1.7,>=1.6.0",
-    "numpy>=2.0",
+    "numpy>=2.0.0",
     "astropy>=5.3.1",
     "astroplan>=0.9",
     "colorcet>=3.0.1",
@@ -37,7 +37,8 @@ dependencies = [
     "qplan @ git+https://github.com/naojsoft/qplan.git",
     "ets-fiber-assigner @ git+https://github.com/Subaru-PFS/ets_fiberalloc.git",
     "ics-cobraOps @ git+https://github.com/Subaru-PFS/ics_cobraOps.git",
-    "pfs-utils @ git+https://github.com/Subaru-PFS/pfs_utils.git",
+    # "pfs-utils @ git+https://github.com/Subaru-PFS/pfs_utils.git",
+    "pfs-utils @ git+https://github.com/Subaru-PFS/pfs_utils.git@w.2025.31",
     "psutil>=6.0.0",
     "hdbscan>=0.8.40",
     "skyfield>=1.53",

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,10 +27,10 @@ mkdocs-material>=9.5.4
 mkdocs-video>=1.5.0
 multiprocess>=0.70.15
 myst-parser>=2.0.0
-numpy>=2.0
+numpy>=2.0.0
 pandas>=2.0.3
 panel<1.7,>=1.6.0
-pfs-utils @ git+https://github.com/Subaru-PFS/pfs_utils.git
+pfs-utils @ git+https://github.com/Subaru-PFS/pfs_utils.git@w.2025.31
 pip>=23.2.1
 psutil>=6.0.0
 pybind11>=2.11.1


### PR DESCRIPTION
`pfs_utils` is going to move to pip-friendly package structure, but it requires more work on other PFS packages. At that moment, `pfs_utils` is pinned to `w2025.31`, which makes a temporary mitigation to accidental upgrade which will fail.