### PR TITLE
append first 7 characters of upload_id to ob_code

### DIFF
--- a/src/pfs_target_uploader/widgets/FileInputWidgets.py
+++ b/src/pfs_target_uploader/widgets/FileInputWidgets.py
@@ -148,4 +148,9 @@ class FileInputWidgets(param.Parameterized):
         if validation_status["required_keys"]["status"]:
             df_output.insert(1, "obj_id_str", df_output["obj_id"].astype(str))
 
+        # append first 7 characters of secret_token to ob_codes
+        df_output["ob_code"] = df_output["ob_code"].apply(
+            lambda x: f"{x}_{self.secret_token[:7]}"
+        )
+
         return validation_status, df_input, df_output


### PR DESCRIPTION
This pull request introduces a change to how `ob_code` values are processed in the `validate` method of `FileInputWidgets.py`. The update appends the first seven characters of `secret_token` to each `ob_code`, which likely helps with tracking or uniquely identifying these codes.

Data processing enhancement:

* In the `validate` method of `FileInputWidgets.py`, the `ob_code` column in `df_output` is now updated to append the first seven characters of `self.secret_token` to each value.