### PR TITLE
Implement dynamic versioning with setuptools-scm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# setuptools-scm version file
+src/pfs_target_uploader/_version.py
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,15 +48,16 @@ license-files = ["LICENSE"]
 pfs-uploader-cli = "pfs_target_uploader.cli.cli_main:app"
 
 [build-system]
-requires = ["setuptools", "wheel", "pybind11"]
+requires = ["setuptools>=64", "setuptools-scm>=8.0", "wheel", "pybind11"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 package-dir = { "" = "src" }
 include-package-data = true
 
-[tool.setuptools.dynamic]
-version = { attr = "pfs_target_uploader.__version__" }
+[tool.setuptools_scm]
+version_file = "src/pfs_target_uploader/_version.py"
+fallback_version = "0.0.0+unknown"
 
 [project.optional-dependencies]
 dev = ["black>=23.7.0", "ruff>=0.5.0", "ty", "ipython>=8.14.0"]

--- a/src/pfs_target_uploader/__init__.py
+++ b/src/pfs_target_uploader/__init__.py
@@ -1,1 +1,4 @@
-__version__ = "3.3.6"
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Summary
Replace manual `__version__` management with automatic version extraction from git tags using setuptools-scm.

## Changes Made
- ✅ Added `setuptools-scm>=8.0` to `[build-system]` requirements in pyproject.toml
- ✅ Replaced `[tool.setuptools.dynamic]` with `[tool.setuptools_scm]` configuration
- ✅ Updated `__init__.py` to import version from auto-generated `_version.py`
- ✅ Added `src/pfs_target_uploader/_version.py` to `.gitignore` (auto-generated file)

## Benefits
- **Automatic versioning**: Version derived from git tags automatically (no manual updates needed)
- **Development versions**: Uncommitted changes get `.devN+gHASH` suffix for clear tracking
- **Build consistency**: Version always matches git state at build time
- **PEP 440 compliance**: Follows Python packaging standards
- **Works with uv/pdm/pip**: Compatible with all package managers

## Version Behavior
- **On tagged commit** (e.g., `v3.3.7`): Version = `3.3.7`
- **Development builds**: Version = `3.3.8.dev5+g1234567` (auto-incremented with commit count and hash)
- **Dirty working tree**: Adds `.d20251220` suffix to indicate uncommitted changes
- **Without git**: Falls back to `0.0.0+unknown`

## Testing
- ✅ Package installation: Successfully installed with `uv pip install -e .`
- ✅ Version detection: Correctly shows `3.3.7.dev21+g102050705.d20251220`
- ✅ Version import: `import pfs_target_uploader; print(__version__)` works correctly
- ✅ Build process: Both wheel and sdist built successfully

## Migration Notes
**No changes needed to release workflow:**
1. Commit all changes
2. Create git tag: `git tag v3.3.7`
3. Push tag: `git push origin v3.3.7`
4. Build package: `uv build` (version automatically extracted)

**Compatibility:**
- ✅ Works with existing git tags (v3.3.6 pattern)
- ✅ No impact on existing functionality
- ✅ Backward compatible with all package managers

## Related Issues
Resolves #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)