### PR TITLE
Make the max individual exposure time to 1800s

### DIFF
--- a/src/pfs_target_uploader/widgets/ObsTypeWidgets.py
+++ b/src/pfs_target_uploader/widgets/ObsTypeWidgets.py
@@ -46,7 +46,7 @@ class ObsTypeWidgets(param.Parameterized):
             value=900,
             step=10,
             start=10,
-            end=7200,
+            end=1800,
             disabled=True,
         )
 


### PR DESCRIPTION
This pull request makes a small adjustment to the `ObsTypeWidgets.py` file, specifically reducing the maximum allowed value for a certain parameter from 7200 to 1800. This likely restricts the user input range for that field.