### PR TITLE
Fix 64-bit integer display in internal duplication table

### DIFF
--- a/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
+++ b/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
@@ -487,7 +487,7 @@ class ValidationResultWidgets:
             # Select and reorder columns for display
             display_columns = [
                 "ob_code",
-                "obj_id",
+                "obj_id_str",
                 "ra",
                 "dec",
                 "resolution",


### PR DESCRIPTION
## Summary
- Use `obj_id_str` instead of `obj_id` in the internal duplication warning table
- Prevents JavaScript's 53-bit integer truncation in Tabulator widget
- Matches the handling already in place for other validation tables and the Input List tab

## Test plan
- [ ] Start the application with `./scripts/serve-app.sh`
- [ ] Upload a target list containing large 64-bit integer `obj_id` values
- [ ] Verify the internal duplication warning table displays `obj_id` correctly
- [ ] Confirm the value matches what is shown in the Input List tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)