### PR TITLE
Add flux range validation based on AB magnitude limits

### DIFF
--- a/.env.shared.example
+++ b/.env.shared.example
@@ -59,6 +59,12 @@ MIN_FLUXMAG=
 # Example: MAX_FLUXMAG=30.0
 MAX_FLUXMAG=
 
+# Minimum AB magnitude (brightest limit) for filler observation type
+# This overrides MIN_FLUXMAG when obs_type is "filler"
+# Leave empty to fall back to MIN_FLUXMAG
+# Example: MIN_FLUXMAG_FILLER=15.0
+MIN_FLUXMAG_FILLER=
+
 # ========================================
 # PPP Performance Optimization Settings
 # ========================================

--- a/.env.shared.example
+++ b/.env.shared.example
@@ -42,6 +42,24 @@ UPLOADID_DB="upload_id.sqlite"
 LOG_LEVEL="INFO"
 
 # ========================================
+# Flux Range Validation Settings
+# ========================================
+
+# Flux range check based on AB magnitude
+# These settings validate that flux values fall within expected magnitude ranges
+# Leave empty or comment out to disable range checking
+
+# Minimum AB magnitude (brightest limit)
+# Targets brighter than this value will trigger a warning
+# Example: MIN_FLUXMAG=10.0
+MIN_FLUXMAG=
+
+# Maximum AB magnitude (faintest limit)
+# Targets fainter than this value will trigger a warning
+# Example: MAX_FLUXMAG=30.0
+MAX_FLUXMAG=
+
+# ========================================
 # PPP Performance Optimization Settings
 # ========================================
 

--- a/.env.shared.example
+++ b/.env.shared.example
@@ -49,21 +49,26 @@ LOG_LEVEL="INFO"
 # These settings validate that flux values fall within expected magnitude ranges
 # Leave empty or comment out to disable range checking
 
-# Minimum AB magnitude (brightest limit)
+# Minimum AB magnitude (brightest limit) for queue observation type
 # Targets brighter than this value will trigger a warning
-# Example: MIN_FLUXMAG=10.0
-MIN_FLUXMAG=
+# Example: MIN_FLUXMAG_QUEUE=10.0
+MIN_FLUXMAG_QUEUE=
+
+# Minimum AB magnitude (brightest limit) for classical observation type
+# Targets brighter than this value will trigger a warning
+# Example: MIN_FLUXMAG_CLASSICAL=12.0
+MIN_FLUXMAG_CLASSICAL=
+
+# Minimum AB magnitude (brightest limit) for filler observation type
+# Targets brighter than this value will trigger a warning
+# Example: MIN_FLUXMAG_FILLER=15.0
+MIN_FLUXMAG_FILLER=
 
 # Maximum AB magnitude (faintest limit)
 # Targets fainter than this value will trigger a warning
+# Applies to all observation types
 # Example: MAX_FLUXMAG=30.0
 MAX_FLUXMAG=
-
-# Minimum AB magnitude (brightest limit) for filler observation type
-# This overrides MIN_FLUXMAG when obs_type is "filler"
-# Leave empty to fall back to MIN_FLUXMAG
-# Example: MIN_FLUXMAG_FILLER=15.0
-MIN_FLUXMAG_FILLER=
 
 # ========================================
 # PPP Performance Optimization Settings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,9 @@ pfs-uploader-cli validate target_list.csv
 # Validate with flux range check (AB magnitude limits)
 pfs-uploader-cli validate target_list.csv --min-mag 10.0 --max-mag 30.0
 
+# Validate filler targets with different bright limit
+pfs-uploader-cli validate target_list.csv --obs-type filler --min-mag 10.0 --max-mag 30.0 --min-mag-filler 15.0
+
 # Run pointing simulation
 pfs-uploader-cli simulate target_list.csv --obstype queue --output-dir output/
 
@@ -262,6 +265,7 @@ PPP_TIMING_VERBOSE=0                # PPP timing logs (0=off, 1=on)
 LOG_LEVEL="INFO"                    # Logging verbosity
 UPLOADID_DB="upload_id.sqlite"      # Upload deduplication database
 MIN_FLUXMAG=""                      # Minimum AB mag (bright limit, optional)
+MIN_FLUXMAG_FILLER=""               # Min AB mag for filler obs_type (optional, falls back to MIN_FLUXMAG)
 MAX_FLUXMAG=""                      # Maximum AB mag (faint limit, optional)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,14 @@ pfs-uploader-cli clean-uid data/upload_id.sqlite
 # Validate a target list
 pfs-uploader-cli validate target_list.csv
 
+# Validate with flux range check (AB magnitude limits)
+pfs-uploader-cli validate target_list.csv --min-mag 10.0 --max-mag 30.0
+
 # Run pointing simulation
-pfs-uploader-cli ppp target_list.csv --obstype queue --output-dir output/
+pfs-uploader-cli simulate target_list.csv --obstype queue --output-dir output/
+
+# Run pointing simulation with flux range check
+pfs-uploader-cli simulate target_list.csv --obstype queue --min-mag 10.0 --max-mag 30.0
 ```
 
 ### Docker and Deployment
@@ -210,6 +216,10 @@ The repository includes a GitHub Actions workflow that automatically updates the
 ### Key Modules
 
 - **`utils/checker.py`**: Target list validation logic with astronomical constraints
+  - Column validation, value range checks, flux validation
+  - Flux range validation against AB magnitude limits (`check_fluxrange()`)
+  - Visibility checking with HEALPix optimization
+  - Internal duplication detection
 - **`utils/internal_duplication.py`**: Internal duplicate detection using coordinate-based clustering
 - **`utils/ppp.py`**: Pointing simulation engine using clustering and optimization algorithms
 - **`utils/io.py`**: File I/O operations for target lists and data persistence
@@ -251,6 +261,8 @@ PPP_QUIET=1                         # Suppress verbose PPP output
 PPP_TIMING_VERBOSE=0                # PPP timing logs (0=off, 1=on)
 LOG_LEVEL="INFO"                    # Logging verbosity
 UPLOADID_DB="upload_id.sqlite"      # Upload deduplication database
+MIN_FLUXMAG=""                      # Minimum AB mag (bright limit, optional)
+MAX_FLUXMAG=""                      # Maximum AB mag (faint limit, optional)
 ```
 
 ## Data Flow
@@ -259,6 +271,7 @@ UPLOADID_DB="upload_id.sqlite"      # Upload deduplication database
 2. **Validation**: `checker.py` validates format, coordinates, magnitudes, and observability
    - **HEALPix Optimization**: Visibility checking uses HEALPix tessellation (nside=32, ~110 arcmin pixels) to group spatially clustered targets, significantly improving performance for large target lists
    - **Internal Duplication Check**: Detects targets within 1.0 arcsec (PFS fiber diameter) using AgglomerativeClustering with complete linkage
+   - **Flux Range Check**: Optional validation of flux values against AB magnitude limits (MIN_FLUXMAG/MAX_FLUXMAG) to identify targets that may be too bright or too faint
 3. **Clustering**: `ppp.py` groups targets spatially using HDBSCAN/DBSCAN algorithms
 4. **Simulation**: Pointing patterns optimized using Gurobi solver with telescope constraints
 5. **Results**: Interactive plots and downloadable files generated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,9 +264,10 @@ PPP_QUIET=1                         # Suppress verbose PPP output
 PPP_TIMING_VERBOSE=0                # PPP timing logs (0=off, 1=on)
 LOG_LEVEL="INFO"                    # Logging verbosity
 UPLOADID_DB="upload_id.sqlite"      # Upload deduplication database
-MIN_FLUXMAG=""                      # Minimum AB mag (bright limit, optional)
-MIN_FLUXMAG_FILLER=""               # Min AB mag for filler obs_type (optional, falls back to MIN_FLUXMAG)
-MAX_FLUXMAG=""                      # Maximum AB mag (faint limit, optional)
+MIN_FLUXMAG_QUEUE=""                # Min AB mag for queue obs_type (bright limit, optional)
+MIN_FLUXMAG_CLASSICAL=""            # Min AB mag for classical obs_type (bright limit, optional)
+MIN_FLUXMAG_FILLER=""               # Min AB mag for filler obs_type (bright limit, optional)
+MAX_FLUXMAG=""                      # Max AB mag (faint limit, optional, shared across all modes)
 ```
 
 ## Data Flow
@@ -275,7 +276,7 @@ MAX_FLUXMAG=""                      # Maximum AB mag (faint limit, optional)
 2. **Validation**: `checker.py` validates format, coordinates, magnitudes, and observability
    - **HEALPix Optimization**: Visibility checking uses HEALPix tessellation (nside=32, ~110 arcmin pixels) to group spatially clustered targets, significantly improving performance for large target lists
    - **Internal Duplication Check**: Detects targets within 1.0 arcsec (PFS fiber diameter) using AgglomerativeClustering with complete linkage
-   - **Flux Range Check**: Optional validation of flux values against AB magnitude limits (MIN_FLUXMAG/MAX_FLUXMAG) to identify targets that may be too bright or too faint
+   - **Flux Range Check**: Optional validation of flux values against AB magnitude limits (MIN_FLUXMAG_QUEUE/CLASSICAL/FILLER for bright limit, MAX_FLUXMAG for faint limit) to identify targets that may be too bright or too faint for the specified observation mode
 3. **Clustering**: `ppp.py` groups targets spatially using HDBSCAN/DBSCAN algorithms
 4. **Simulation**: Pointing patterns optimized using Gurobi solver with telescope constraints
 5. **Results**: Interactive plots and downloadable files generated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,14 +117,17 @@ pfs-uploader-cli validate target_list.csv
 # Validate with flux range check (AB magnitude limits)
 pfs-uploader-cli validate target_list.csv --min-mag 10.0 --max-mag 30.0
 
+# Validate queue targets with magnitude limits
+pfs-uploader-cli validate target_list.csv --obs-type queue --min-mag 10.0 --max-mag 30.0
+
 # Validate filler targets with different bright limit
-pfs-uploader-cli validate target_list.csv --obs-type filler --min-mag 10.0 --max-mag 30.0 --min-mag-filler 15.0
+pfs-uploader-cli validate target_list.csv --obs-type filler --min-mag 15.0 --max-mag 30.0
 
 # Run pointing simulation
-pfs-uploader-cli simulate target_list.csv --obstype queue --output-dir output/
+pfs-uploader-cli simulate target_list.csv --obs-type queue -d output/
 
 # Run pointing simulation with flux range check
-pfs-uploader-cli simulate target_list.csv --obstype queue --min-mag 10.0 --max-mag 30.0
+pfs-uploader-cli simulate target_list.csv --obs-type queue --min-mag 10.0 --max-mag 30.0
 ```
 
 ### Docker and Deployment

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ ANN_FILE="user_announcement.md"
 # The file will be created under $OUTPUT_DIR
 UPLOADID_DB="upload_id.sqlite"
 
+# Flux range validation based on AB magnitude
+# Leave empty or comment out to disable range checking
+# MIN_FLUXMAG=10.0   # Brightest allowed magnitude
+# MAX_FLUXMAG=30.0   # Faintest allowed magnitude
+
 # loggging level
 # DEBUG, INFO (default), WARNING, ERROR, or CRITICAL
 LOG_LEVEL="INFO"

--- a/README.md
+++ b/README.md
@@ -129,8 +129,12 @@ UPLOADID_DB="upload_id.sqlite"
 
 # Flux range validation based on AB magnitude
 # Leave empty or comment out to disable range checking
-# MIN_FLUXMAG=10.0   # Brightest allowed magnitude
-# MAX_FLUXMAG=30.0   # Faintest allowed magnitude
+# Minimum AB magnitude (brightest limit) - observation mode specific
+# MIN_FLUXMAG_QUEUE=10.0      # For queue observation type
+# MIN_FLUXMAG_CLASSICAL=12.0  # For classical observation type
+# MIN_FLUXMAG_FILLER=15.0     # For filler observation type
+# Maximum AB magnitude (faintest limit) - shared across all modes
+# MAX_FLUXMAG=30.0
 
 # loggging level
 # DEBUG, INFO (default), WARNING, ERROR, or CRITICAL

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -56,6 +56,7 @@ $ pfs-uploader-cli validate [OPTIONS] INPUT_LIST
 - `--obs-type [queue|classical|filler]`: Observation type. [default: queue]
 - `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
 - `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
+- `--min-mag-filler FLOAT`: Minimum AB magnitude (brightest limit) for filler observation type. Overrides --min-mag when --obs-type is &#x27;filler&#x27;. None means fall back to --min-mag.
 - `--log-level [debug|info|warning|error|critical]`: Set the log level. [default: INFO]
 - `--help`: Show this message and exit.
 
@@ -87,6 +88,7 @@ $ pfs-uploader-cli simulate [OPTIONS] INPUT_LIST
 - `--obs-type [queue|classical|filler]`: Observation type. [default: queue]
 - `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
 - `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
+- `--min-mag-filler FLOAT`: Minimum AB magnitude (brightest limit) for filler observation type. Overrides --min-mag when --obs-type is &#x27;filler&#x27;. None means fall back to --min-mag.
 - `--log-level [debug|info|warning|error|critical]`: Set the log level. [default: INFO]
 - `--help`: Show this message and exit.
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -21,38 +21,43 @@ $ pfs-uploader-cli [OPTIONS] COMMAND [ARGS]...
 
 **Options**:
 
-* `--help`: Show this message and exit.
+- `--help`: Show this message and exit.
 
 **Commands**:
 
-* `clean-uid`: Remove duplicates from a SQLite database...
-* `simulate`: Run the online PPP to simulate pointings.
-* `start-app`: Launch the PFS Target Uploader Web App.
-* `uid2sqlite`: Generate a SQLite database of upload_id
-* `validate`: Validate a target list for PFS openuse.
+- `validate`: Validate a target list for PFS openuse.
+- `simulate`: Run the online PPP to simulate pointings.
+- `start-app`: Launch the PFS Target Uploader Web App.
+- `uid2sqlite`: Generate a SQLite database of upload_id
+- `clean-uid`: Remove duplicates from a SQLite database...
 
 ---
 
-### `clean-uid`
+### `validate`
 
-Remove duplicates from a SQLite database of upload_id
+Validate a target list for PFS openuse.
 
 **Usage**:
 
 ```console
-$ pfs-uploader-cli clean-uid [OPTIONS] DBFILE
+$ pfs-uploader-cli validate [OPTIONS] INPUT_LIST
 ```
 
 **Arguments**:
 
-* `DBFILE`: Full path to the SQLite database file.  [required]
+- `INPUT_LIST`: Input CSV file. [required]
 
 **Options**:
 
-* `--backup / --no-backup`: Create a backup of the database before cleaning. Default is True.  [default: backup]
-* `--dry-run / --no-dry-run`: Do not remove duplicates; just check the duplicates. Default is False.  [default: no-dry-run]
-* `--log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]`: Set the log level.  [default: INFO]
-* `--help`: Show this message and exit.
+- `-d, --dir TEXT`: Output directory to save the results. [default: .]
+- `--date-begin TEXT`: Begin date (e.g., 2023-02-01). The default is the first date of the next Subaru semester.
+- `--date-end TEXT`: End date (e.g., 2023-07-31). The default is the last date of the next Subaru semester.
+- `--save / --no-save`: Save the validated target list in the directory specified by &quot;--dir&quot;. [default: no-save]
+- `--obs-type [queue|classical|filler]`: Observation type. [default: queue]
+- `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
+- `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
+- `--log-level [debug|info|warning|error|critical]`: Set the log level. [default: INFO]
+- `--help`: Show this message and exit.
 
 ---
 
@@ -70,20 +75,20 @@ $ pfs-uploader-cli simulate [OPTIONS] INPUT_LIST
 
 **Arguments**:
 
-* `INPUT_LIST`: Input CSV file  [required]
+- `INPUT_LIST`: Input CSV file [required]
 
 **Options**:
 
-* `-d, --dir TEXT`: Output directory to save the results.  [default: .]
-* `--date-begin TEXT`: Begin date (e.g., 2023-02-01). The default is the first date of the next Subaru semester.
-* `--date-end TEXT`: End date (e.g., 2023-07-31). The default is the last date of the next Subaru semester.
-* `--single-exptime INTEGER`: Single exposure time (s).  [default: 900]
-* `--max-exec-time INTEGER`: Max execution time (s). 0 means no limit.  [default: 0]
-* `--obs-type [queue|classical|filler]`: Observation type.  [default: queue]
-* `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
-* `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
-* `--log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]`: Set the log level.  [default: INFO]
-* `--help`: Show this message and exit.
+- `-d, --dir TEXT`: Output directory to save the results. [default: .]
+- `--date-begin TEXT`: Begin date (e.g., 2023-02-01). The default is the first date of the next Subaru semester.
+- `--date-end TEXT`: End date (e.g., 2023-07-31). The default is the last date of the next Subaru semester.
+- `--single-exptime INTEGER`: Single exposure time (s). [default: 900]
+- `--max-exec-time INTEGER`: Max execution time (s). 0 means no limit. [default: 0]
+- `--obs-type [queue|classical|filler]`: Observation type. [default: queue]
+- `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
+- `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
+- `--log-level [debug|info|warning|error|critical]`: Set the log level. [default: INFO]
+- `--help`: Show this message and exit.
 
 ---
 
@@ -99,23 +104,23 @@ $ pfs-uploader-cli start-app [OPTIONS] APP:{uploader|admin}
 
 **Arguments**:
 
-* `APP:{uploader|admin}`: App to launch.  [required]
+- `APP:{uploader|admin}`: App to launch. [required]
 
 **Options**:
 
-* `--port INTEGER`: Port number to run the server.  [default: 5008]
-* `--prefix TEXT`: URL prefix to serve the app.
-* `--allow-websocket-origin TEXT`: Allow websocket origin.
-* `--static-dirs TEXT`: Static directories.
-* `--use-xheaders / --no-use-xheaders`: Set --use-xheaders option.  [default: no-use-xheaders]
-* `--num-procs INTEGER`: Number of processes to run.  [default: 1]
-* `--autoreload / --no-autoreload`: Set --autoreload option.  [default: no-autoreload]
-* `--max-upload-size INTEGER`: Maximum file size in MB.  [default: 500]
-* `--session-token-expiration INTEGER`: Session token expiration time in seconds.  [default: 1800]
-* `--basic-auth TEXT`: Basic authentication config (.json).
-* `--basic-login-template TEXT`: Basic login template.
-* `--log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]`: Set the log level.  [default: INFO]
-* `--help`: Show this message and exit.
+- `--port INTEGER`: Port number to run the server. [default: 5008]
+- `--prefix TEXT`: URL prefix to serve the app.
+- `--allow-websocket-origin TEXT`: Allow websocket origin.
+- `--static-dirs TEXT`: Static directories.
+- `--use-xheaders / --no-use-xheaders`: Set --use-xheaders option. [default: no-use-xheaders]
+- `--num-procs INTEGER`: Number of processes to run. [default: 1]
+- `--autoreload / --no-autoreload`: Set --autoreload option. [default: no-autoreload]
+- `--max-upload-size INTEGER`: Maximum file size in MB. [default: 500]
+- `--session-token-expiration INTEGER`: Session token expiration time in seconds. [default: 1800]
+- `--basic-auth TEXT`: Basic authentication config (.json).
+- `--basic-login-template TEXT`: Basic login template.
+- `--log-level [debug|info|warning|error|critical]`: Set the log level. [default: INFO]
+- `--help`: Show this message and exit.
 
 ---
 
@@ -131,41 +136,36 @@ $ pfs-uploader-cli uid2sqlite [OPTIONS] [INPUT_LIST]
 
 **Arguments**:
 
-* `[INPUT_LIST]`: Input CSV file.
+- `[INPUT_LIST]`: Input CSV file.
 
 **Options**:
 
-* `-d, --dir TEXT`: Output directory to save the results.  [default: .]
-* `--db TEXT`: Filename of the SQLite database to save the upload_id.  [default: upload_id.sqlite]
-* `--scan-dir TEXT`: Directory to scan for the upload_id. Default is None (use input file)
-* `--clean`: Remove duplicates from the database. Default is False.
-* `--log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]`: Set the log level.  [default: INFO]
-* `--help`: Show this message and exit.
+- `-d, --dir TEXT`: Output directory to save the results. [default: .]
+- `--db TEXT`: Filename of the SQLite database to save the upload_id. [default: upload_id.sqlite]
+- `--scan-dir TEXT`: Directory to scan for the upload_id. Default is None (use input file)
+- `--clean`: Remove duplicates from the database. Default is False.
+- `--log-level [debug|info|warning|error|critical]`: Set the log level. [default: INFO]
+- `--help`: Show this message and exit.
 
 ---
 
-### `validate`
+### `clean-uid`
 
-Validate a target list for PFS openuse.
+Remove duplicates from a SQLite database of upload_id
 
 **Usage**:
 
 ```console
-$ pfs-uploader-cli validate [OPTIONS] INPUT_LIST
+$ pfs-uploader-cli clean-uid [OPTIONS] DBFILE
 ```
 
 **Arguments**:
 
-* `INPUT_LIST`: Input CSV file.  [required]
+- `DBFILE`: Full path to the SQLite database file. [required]
 
 **Options**:
 
-* `-d, --dir TEXT`: Output directory to save the results.  [default: .]
-* `--date-begin TEXT`: Begin date (e.g., 2023-02-01). The default is the first date of the next Subaru semester.
-* `--date-end TEXT`: End date (e.g., 2023-07-31). The default is the last date of the next Subaru semester.
-* `--save / --no-save`: Save the validated target list in the directory specified by "--dir".  [default: no-save]
-* `--obs-type [queue|classical|filler]`: Observation type.  [default: queue]
-* `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
-* `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
-* `--log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]`: Set the log level.  [default: INFO]
-* `--help`: Show this message and exit.
+- `--backup / --no-backup`: Create a backup of the database before cleaning. Default is True. [default: backup]
+- `--dry-run / --no-dry-run`: Do not remove duplicates; just check the duplicates. Default is False. [default: no-dry-run]
+- `--log-level [debug|info|warning|error|critical]`: Set the log level. [default: INFO]
+- `--help`: Show this message and exit.

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -80,6 +80,8 @@ $ pfs-uploader-cli simulate [OPTIONS] INPUT_LIST
 * `--single-exptime INTEGER`: Single exposure time (s).  [default: 900]
 * `--max-exec-time INTEGER`: Max execution time (s). 0 means no limit.  [default: 0]
 * `--obs-type [queue|classical|filler]`: Observation type.  [default: queue]
+* `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
+* `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
 * `--log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]`: Set the log level.  [default: INFO]
 * `--help`: Show this message and exit.
 
@@ -163,5 +165,7 @@ $ pfs-uploader-cli validate [OPTIONS] INPUT_LIST
 * `--date-end TEXT`: End date (e.g., 2023-07-31). The default is the last date of the next Subaru semester.
 * `--save / --no-save`: Save the validated target list in the directory specified by "--dir".  [default: no-save]
 * `--obs-type [queue|classical|filler]`: Observation type.  [default: queue]
+* `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
+* `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
 * `--log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]`: Set the log level.  [default: INFO]
 * `--help`: Show this message and exit.

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -56,7 +56,6 @@ $ pfs-uploader-cli validate [OPTIONS] INPUT_LIST
 - `--obs-type [queue|classical|filler]`: Observation type. [default: queue]
 - `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
 - `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
-- `--min-mag-filler FLOAT`: Minimum AB magnitude (brightest limit) for filler observation type. Overrides --min-mag when --obs-type is &#x27;filler&#x27;. None means fall back to --min-mag.
 - `--log-level [debug|info|warning|error|critical]`: Set the log level. [default: INFO]
 - `--help`: Show this message and exit.
 
@@ -88,7 +87,6 @@ $ pfs-uploader-cli simulate [OPTIONS] INPUT_LIST
 - `--obs-type [queue|classical|filler]`: Observation type. [default: queue]
 - `--min-mag FLOAT`: Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit.
 - `--max-mag FLOAT`: Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit.
-- `--min-mag-filler FLOAT`: Minimum AB magnitude (brightest limit) for filler observation type. Overrides --min-mag when --obs-type is &#x27;filler&#x27;. None means fall back to --min-mag.
 - `--log-level [debug|info|warning|error|critical]`: Set the log level. [default: INFO]
 - `--help`: Show this message and exit.
 

--- a/docs/docs/inputs.md
+++ b/docs/docs/inputs.md
@@ -115,7 +115,9 @@ Flux columns must conform to the following requirements.
   the value of the first column (the left-most one in the input CSV file) will be used.
 - Flux values are in the unit of <font size=5>**nJy**</font> (nano-Jansky).
 - Flux values are assumed to be total flux.
-- Errors can be provided by using column names by adding `_error` following the filter names.
+- Flux errors can be provided by using column names by adding `_error` following the filter names.
+- All **queue-mode** targets must be fainter than **16 AB mag** in all provided filters.
+- All **filler-mode** targets must be fainter than **17 AB mag** in all provided filters.
 
 ##### Example of flux information
 

--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -94,6 +94,22 @@ Flux values are checked to identify potential unit errors (magnitude vs. nano-Ja
 
     This validation does not prevent submission. It serves as a reminder to verify that flux values are provided in nJy, not in other units such as magnitudes, Jy (Jansky), or mJy (milli-Jansky).
 
+### Flux range (AB magnitude)
+
+Flux values will be checked against specified AB magnitude limits to identify targets that may be too bright or too faint for observations.
+
+!!! warning "Warning message is raised as follows"
+
+    `N/M` flux values are brighter than AB magnitude `XX.X` / fainter than AB magnitude `XX.X` / outside AB magnitude range [`XX.X`, `XX.X`]. Please verify that these targets are intended to be outside this range.
+
+!!! success "Info message is shown as follows"
+
+    All flux values are within AB magnitude range [`XX.X`, `XX.X`] / not brighter than AB magnitude `XX.X` / not fainter than AB magnitude `XX.X`.
+
+!!! note "This is a warning-only check"
+
+    This validation does not prevent submission. It serves as a reminder to verify that targets outside the specified magnitude range are intentional. However, targets with flux values outside the specified range may be removed during the observation planning process.
+
 ### Target visibility
 
 Target visibility is checked by comparing the requested exposure time is shorter than the time when the target elevation is more than 30 degrees above the horizon between 18:30 and 5:30+1day. The data range can be configured in the `config` tab in the sidebar. Only visible targets will be considered for the pointing simulation. Along with the error and warning messages, invalid rows will be displayed.

--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -78,7 +78,7 @@ Flux columns are validated against conditions described in the [Flux Information
 
     All `ob_code`s have at least one flux information. The detected filters are the following: `<detected filter columns>`
 
-### Flux values
+### Suspicious flux values
 
 Flux values are checked to identify potential unit errors (magnitude vs. nano-Jansky). If a significant fraction (≥90%) of flux values fall in the range 10-30, a warning is issued as this range is typical for magnitudes but suspicious for nJy values.
 
@@ -94,9 +94,9 @@ Flux values are checked to identify potential unit errors (magnitude vs. nano-Ja
 
     This validation does not prevent submission. It serves as a reminder to verify that flux values are provided in nJy, not in other units such as magnitudes, Jy (Jansky), or mJy (milli-Jansky).
 
-### Flux range (AB magnitude)
+### Flux range
 
-Flux values will be checked against specified AB magnitude limits to identify targets that may be too bright or too faint for observations.
+Flux values will be checked against flux/magnitude limits to identify targets that may be too bright or too faint for observations.
 
 !!! warning "Warning message is raised as follows"
 

--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -97,6 +97,7 @@ Flux values are checked to identify potential unit errors (magnitude vs. nano-Ja
 ### Flux range
 
 Flux values are additionally checked against flux/magnitude limits to identify targets that may be too bright or too faint for observations.
+The current bright magnitude limit is set to **16 AB mag for queue-mode** targets and **17 AB mag for filler-mode** targets in all provided filters.
 
 !!! warning "Warning message is raised as follows"
 

--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -96,7 +96,7 @@ Flux values are checked to identify potential unit errors (magnitude vs. nano-Ja
 
 ### Flux range
 
-Flux values will be checked against flux/magnitude limits to identify targets that may be too bright or too faint for observations.
+Flux values are additionally checked against flux/magnitude limits to identify targets that may be too bright or too faint for observations.
 
 !!! warning "Warning message is raised as follows"
 

--- a/src/pfs_target_uploader/cli/cli_main.py
+++ b/src/pfs_target_uploader/cli/cli_main.py
@@ -89,6 +89,13 @@ def validate(
             help="Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit."
         ),
     ] = None,
+    min_mag_filler: Annotated[
+        float | None,
+        typer.Option(
+            help="Minimum AB magnitude (brightest limit) for filler observation type. "
+            "Overrides --min-mag when --obs-type is 'filler'. None means fall back to --min-mag."
+        ),
+    ] = None,
     log_level: Annotated[
         LogLevel, typer.Option(case_sensitive=False, help="Set the log level.")
     ] = LogLevel.INFO,
@@ -108,8 +115,15 @@ def validate(
 
         date_end = None if date_end is None else date.fromisoformat(date_end)
 
+        # Select min_mag based on observation type
+        effective_min_mag = min_mag
+        if obs_type.value == "filler":
+            effective_min_mag = min_mag_filler
+            if effective_min_mag is not None:
+                logger.info(f"Using filler-specific min_mag: {effective_min_mag}")
+
         validation_status, df_validated = validate_input(
-            df_input, date_begin=date_begin, date_end=date_end, min_mag=min_mag, max_mag=max_mag
+            df_input, date_begin=date_begin, date_end=date_end, min_mag=effective_min_mag, max_mag=max_mag
         )
 
     if validation_status["status"] is False:
@@ -185,6 +199,13 @@ def simulate(
             help="Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit."
         ),
     ] = None,
+    min_mag_filler: Annotated[
+        float | None,
+        typer.Option(
+            help="Minimum AB magnitude (brightest limit) for filler observation type. "
+            "Overrides --min-mag when --obs-type is 'filler'. None means fall back to --min-mag."
+        ),
+    ] = None,
     log_level: Annotated[
         LogLevel, typer.Option(case_sensitive=False, help="Set the log level.")
     ] = LogLevel.INFO,
@@ -212,8 +233,15 @@ def simulate(
         date_begin = None if date_begin is None else date.fromisoformat(date_begin)
         date_end = None if date_end is None else date.fromisoformat(date_end)
 
+        # Select min_mag based on observation type
+        effective_min_mag = min_mag
+        if obs_type.value == "filler":
+            effective_min_mag = min_mag_filler
+            if effective_min_mag is not None:
+                logger.info(f"Using filler-specific min_mag: {effective_min_mag}")
+
         validation_status, df_validated = validate_input(
-            df_input, date_begin=date_begin, date_end=date_end, min_mag=min_mag, max_mag=max_mag
+            df_input, date_begin=date_begin, date_end=date_end, min_mag=effective_min_mag, max_mag=max_mag
         )
 
         if validation_status["status"] is False:

--- a/src/pfs_target_uploader/cli/cli_main.py
+++ b/src/pfs_target_uploader/cli/cli_main.py
@@ -89,13 +89,6 @@ def validate(
             help="Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit."
         ),
     ] = None,
-    min_mag_filler: Annotated[
-        float | None,
-        typer.Option(
-            help="Minimum AB magnitude (brightest limit) for filler observation type. "
-            "Overrides --min-mag when --obs-type is 'filler'. None means fall back to --min-mag."
-        ),
-    ] = None,
     log_level: Annotated[
         LogLevel, typer.Option(case_sensitive=False, help="Set the log level.")
     ] = LogLevel.INFO,
@@ -115,15 +108,12 @@ def validate(
 
         date_end = None if date_end is None else date.fromisoformat(date_end)
 
-        # Select min_mag based on observation type
-        effective_min_mag = min_mag
-        if obs_type.value == "filler":
-            effective_min_mag = min_mag_filler
-            if effective_min_mag is not None:
-                logger.info(f"Using filler-specific min_mag: {effective_min_mag}")
-
         validation_status, df_validated = validate_input(
-            df_input, date_begin=date_begin, date_end=date_end, min_mag=effective_min_mag, max_mag=max_mag
+            df_input,
+            date_begin=date_begin,
+            date_end=date_end,
+            min_mag=min_mag,
+            max_mag=max_mag,
         )
 
     if validation_status["status"] is False:
@@ -199,13 +189,6 @@ def simulate(
             help="Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit."
         ),
     ] = None,
-    min_mag_filler: Annotated[
-        float | None,
-        typer.Option(
-            help="Minimum AB magnitude (brightest limit) for filler observation type. "
-            "Overrides --min-mag when --obs-type is 'filler'. None means fall back to --min-mag."
-        ),
-    ] = None,
     log_level: Annotated[
         LogLevel, typer.Option(case_sensitive=False, help="Set the log level.")
     ] = LogLevel.INFO,
@@ -233,15 +216,12 @@ def simulate(
         date_begin = None if date_begin is None else date.fromisoformat(date_begin)
         date_end = None if date_end is None else date.fromisoformat(date_end)
 
-        # Select min_mag based on observation type
-        effective_min_mag = min_mag
-        if obs_type.value == "filler":
-            effective_min_mag = min_mag_filler
-            if effective_min_mag is not None:
-                logger.info(f"Using filler-specific min_mag: {effective_min_mag}")
-
         validation_status, df_validated = validate_input(
-            df_input, date_begin=date_begin, date_end=date_end, min_mag=effective_min_mag, max_mag=max_mag
+            df_input,
+            date_begin=date_begin,
+            date_end=date_end,
+            min_mag=min_mag,
+            max_mag=max_mag,
         )
 
         if validation_status["status"] is False:

--- a/src/pfs_target_uploader/cli/cli_main.py
+++ b/src/pfs_target_uploader/cli/cli_main.py
@@ -78,13 +78,13 @@ def validate(
     ] = False,
     obs_type: Annotated[ObsType, typer.Option(help="Observation type.")] = "queue",
     min_mag: Annotated[
-        float,
+        float | None,
         typer.Option(
             help="Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit."
         ),
     ] = None,
     max_mag: Annotated[
-        float,
+        float | None,
         typer.Option(
             help="Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit."
         ),
@@ -174,13 +174,13 @@ def simulate(
     ] = 0,
     obs_type: Annotated[ObsType, typer.Option(help="Observation type.")] = "queue",
     min_mag: Annotated[
-        float,
+        float | None,
         typer.Option(
             help="Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit."
         ),
     ] = None,
     max_mag: Annotated[
-        float,
+        float | None,
         typer.Option(
             help="Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit."
         ),

--- a/src/pfs_target_uploader/cli/cli_main.py
+++ b/src/pfs_target_uploader/cli/cli_main.py
@@ -77,6 +77,18 @@ def validate(
         ),
     ] = False,
     obs_type: Annotated[ObsType, typer.Option(help="Observation type.")] = "queue",
+    min_mag: Annotated[
+        float,
+        typer.Option(
+            help="Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit."
+        ),
+    ] = None,
+    max_mag: Annotated[
+        float,
+        typer.Option(
+            help="Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit."
+        ),
+    ] = None,
     log_level: Annotated[
         LogLevel, typer.Option(case_sensitive=False, help="Set the log level.")
     ] = LogLevel.INFO,
@@ -97,7 +109,7 @@ def validate(
         date_end = None if date_end is None else date.fromisoformat(date_end)
 
         validation_status, df_validated = validate_input(
-            df_input, date_begin=date_begin, date_end=date_end
+            df_input, date_begin=date_begin, date_end=date_end, min_mag=min_mag, max_mag=max_mag
         )
 
     if validation_status["status"] is False:
@@ -161,6 +173,18 @@ def simulate(
         ),
     ] = 0,
     obs_type: Annotated[ObsType, typer.Option(help="Observation type.")] = "queue",
+    min_mag: Annotated[
+        float,
+        typer.Option(
+            help="Minimum AB magnitude (brightest limit) for flux range check. None means no bright limit."
+        ),
+    ] = None,
+    max_mag: Annotated[
+        float,
+        typer.Option(
+            help="Maximum AB magnitude (faintest limit) for flux range check. None means no faint limit."
+        ),
+    ] = None,
     log_level: Annotated[
         LogLevel, typer.Option(case_sensitive=False, help="Set the log level.")
     ] = LogLevel.INFO,
@@ -189,7 +213,7 @@ def simulate(
         date_end = None if date_end is None else date.fromisoformat(date_end)
 
         validation_status, df_validated = validate_input(
-            df_input, date_begin=date_begin, date_end=date_end
+            df_input, date_begin=date_begin, date_end=date_end, min_mag=min_mag, max_mag=max_mag
         )
 
         if validation_status["status"] is False:

--- a/src/pfs_target_uploader/pn_app.py
+++ b/src/pfs_target_uploader/pn_app.py
@@ -38,6 +38,19 @@ def _toggle_widgets(widgets: list, disabled: bool = True):
         w.disabled = disabled
 
 
+def _get_min_fluxmag_for_obstype(
+    obs_type: str, min_fluxmag: float | None, min_fluxmag_filler: float | None
+) -> float | None:
+    """Select appropriate minimum flux magnitude based on observation type.
+
+    For 'filler' obs_type, returns min_fluxmag_filler (which may be None).
+    For other obs_types, returns min_fluxmag.
+    """
+    if obs_type == "filler":
+        return min_fluxmag_filler
+    return min_fluxmag
+
+
 def target_uploader_app(use_panel_cli=False):
     pn.state.notifications.position = "bottom-left"
 
@@ -108,6 +121,14 @@ def target_uploader_app(use_panel_cli=False):
             logger.info(f"MAX_FLUXMAG is set to {max_fluxmag}")
         except ValueError:
             logger.warning(f"Invalid MAX_FLUXMAG value: {config['MAX_FLUXMAG']}")
+    # Load MIN_FLUXMAG_FILLER (optional, falls back to MIN_FLUXMAG)
+    min_fluxmag_filler = None
+    if "MIN_FLUXMAG_FILLER" in config.keys() and config["MIN_FLUXMAG_FILLER"] != "":
+        try:
+            min_fluxmag_filler = float(config["MIN_FLUXMAG_FILLER"])
+            logger.info(f"MIN_FLUXMAG_FILLER is set to {min_fluxmag_filler}")
+        except ValueError:
+            logger.warning(f"Invalid MIN_FLUXMAG_FILLER value: {config['MIN_FLUXMAG_FILLER']}")
 
     logger.info(f"config params from dotenv: {config}")
 
@@ -348,12 +369,17 @@ def target_uploader_app(use_panel_cli=False):
 
         panel_timer.timer(on=True, time_limit=False)
 
+        # Select min_mag based on observation type
+        effective_min_mag = _get_min_fluxmag_for_obstype(
+            panel_obs_type.obs_type.value, min_fluxmag, min_fluxmag_filler
+        )
+
         validation_status, df_input, df_validated = await asyncio.to_thread(
             panel_input.validate,
             date_begin=panel_dates.date_begin.value,
             date_end=panel_dates.date_end.value,
             single_exptime=panel_obs_type.single_exptime.value,
-            min_mag=min_fluxmag,
+            min_mag=effective_min_mag,
             max_mag=max_fluxmag,
         )
 
@@ -420,12 +446,17 @@ def target_uploader_app(use_panel_cli=False):
 
         panel_timer.timer(on=True, time_limit=False)
 
+        # Select min_mag based on observation type
+        effective_min_mag = _get_min_fluxmag_for_obstype(
+            panel_obs_type.obs_type.value, min_fluxmag, min_fluxmag_filler
+        )
+
         validation_status, df_input_, df_validated = await asyncio.to_thread(
             panel_input.validate,
             date_begin=panel_dates.date_begin.value,
             date_end=panel_dates.date_end.value,
             single_exptime=panel_obs_type.single_exptime.value,
-            min_mag=min_fluxmag,
+            min_mag=effective_min_mag,
             max_mag=max_fluxmag,
         )
         df_ppc = await asyncio.to_thread(panel_ppcinput.validate)
@@ -561,11 +592,16 @@ def target_uploader_app(use_panel_cli=False):
         # do the validation again and again (input file can be different)
         # and I don't know how to implement to return value
         # from callback to another function (sorry)
+        # Select min_mag based on observation type
+        effective_min_mag = _get_min_fluxmag_for_obstype(
+            panel_obs_type.obs_type.value, min_fluxmag, min_fluxmag_filler
+        )
+
         validation_status, df_input, df_validated = await asyncio.to_thread(
             panel_input.validate,
             date_begin=panel_dates.date_begin.value,
             date_end=panel_dates.date_end.value,
-            min_mag=min_fluxmag,
+            min_mag=effective_min_mag,
             max_mag=max_fluxmag,
         )
 

--- a/src/pfs_target_uploader/pn_app.py
+++ b/src/pfs_target_uploader/pn_app.py
@@ -93,6 +93,22 @@ def target_uploader_app(use_panel_cli=False):
 
     logger.info(f"Maximum execution time for the PPP is set to {max_exetime} sec.")
 
+    # Flux range check parameters (AB magnitude)
+    min_fluxmag = None
+    max_fluxmag = None
+    if "MIN_FLUXMAG" in config.keys() and config["MIN_FLUXMAG"] != "":
+        try:
+            min_fluxmag = float(config["MIN_FLUXMAG"])
+            logger.info(f"MIN_FLUXMAG is set to {min_fluxmag}")
+        except ValueError:
+            logger.warning(f"Invalid MIN_FLUXMAG value: {config['MIN_FLUXMAG']}")
+    if "MAX_FLUXMAG" in config.keys() and config["MAX_FLUXMAG"] != "":
+        try:
+            max_fluxmag = float(config["MAX_FLUXMAG"])
+            logger.info(f"MAX_FLUXMAG is set to {max_fluxmag}")
+        except ValueError:
+            logger.warning(f"Invalid MAX_FLUXMAG value: {config['MAX_FLUXMAG']}")
+
     logger.info(f"config params from dotenv: {config}")
 
     if os.path.exists(config["OUTPUT_DIR"]):
@@ -337,6 +353,8 @@ def target_uploader_app(use_panel_cli=False):
             date_begin=panel_dates.date_begin.value,
             date_end=panel_dates.date_end.value,
             single_exptime=panel_obs_type.single_exptime.value,
+            min_mag=min_fluxmag,
+            max_mag=max_fluxmag,
         )
 
         _toggle_widgets(widget_set, disabled=False)
@@ -407,6 +425,8 @@ def target_uploader_app(use_panel_cli=False):
             date_begin=panel_dates.date_begin.value,
             date_end=panel_dates.date_end.value,
             single_exptime=panel_obs_type.single_exptime.value,
+            min_mag=min_fluxmag,
+            max_mag=max_fluxmag,
         )
         df_ppc = await asyncio.to_thread(panel_ppcinput.validate)
 
@@ -545,6 +565,8 @@ def target_uploader_app(use_panel_cli=False):
             panel_input.validate,
             date_begin=panel_dates.date_begin.value,
             date_end=panel_dates.date_end.value,
+            min_mag=min_fluxmag,
+            max_mag=max_fluxmag,
         )
 
         if (validation_status is None) or (not validation_status["status"]):

--- a/src/pfs_target_uploader/pn_app.py
+++ b/src/pfs_target_uploader/pn_app.py
@@ -148,6 +148,22 @@ def target_uploader_app(use_panel_cli=False):
         except ValueError:
             logger.warning(f"Invalid MAX_FLUXMAG value: {config['MAX_FLUXMAG']}")
 
+    # Validate magnitude range consistency for each observation mode
+    for mode_name, min_mag in [
+        ("queue", min_fluxmag_queue),
+        ("classical", min_fluxmag_classical),
+        ("filler", min_fluxmag_filler),
+    ]:
+        if min_mag is not None and max_fluxmag is not None:
+            if min_mag > max_fluxmag:
+                error_msg = (
+                    f"Configuration error for {mode_name} mode: "
+                    f"MIN_FLUXMAG_{mode_name.upper()} ({min_mag}) > MAX_FLUXMAG ({max_fluxmag}). "
+                    f"MIN_FLUXMAG should be brighter (smaller value) than MAX_FLUXMAG."
+                )
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+
     logger.info(f"config params from dotenv: {config}")
 
     if os.path.exists(config["OUTPUT_DIR"]):

--- a/src/pfs_target_uploader/pn_app.py
+++ b/src/pfs_target_uploader/pn_app.py
@@ -39,16 +39,23 @@ def _toggle_widgets(widgets: list, disabled: bool = True):
 
 
 def _get_min_fluxmag_for_obstype(
-    obs_type: str, min_fluxmag: float | None, min_fluxmag_filler: float | None
+    obs_type: str,
+    min_fluxmag_queue: float | None,
+    min_fluxmag_classical: float | None,
+    min_fluxmag_filler: float | None,
 ) -> float | None:
     """Select appropriate minimum flux magnitude based on observation type.
 
-    For 'filler' obs_type, returns min_fluxmag_filler (which may be None).
-    For other obs_types, returns min_fluxmag.
+    Returns the mode-specific minimum flux magnitude (brightest limit).
+    Returns None if the corresponding config is not set.
     """
-    if obs_type == "filler":
+    if obs_type == "queue":
+        return min_fluxmag_queue
+    elif obs_type == "classical":
+        return min_fluxmag_classical
+    elif obs_type == "filler":
         return min_fluxmag_filler
-    return min_fluxmag
+    return None
 
 
 def target_uploader_app(use_panel_cli=False):
@@ -107,21 +114,23 @@ def target_uploader_app(use_panel_cli=False):
     logger.info(f"Maximum execution time for the PPP is set to {max_exetime} sec.")
 
     # Flux range check parameters (AB magnitude)
-    min_fluxmag = None
-    max_fluxmag = None
-    if "MIN_FLUXMAG" in config.keys() and config["MIN_FLUXMAG"] != "":
+    # Load mode-specific minimum flux magnitudes
+    min_fluxmag_queue = None
+    if "MIN_FLUXMAG_QUEUE" in config.keys() and config["MIN_FLUXMAG_QUEUE"] != "":
         try:
-            min_fluxmag = float(config["MIN_FLUXMAG"])
-            logger.info(f"MIN_FLUXMAG is set to {min_fluxmag}")
+            min_fluxmag_queue = float(config["MIN_FLUXMAG_QUEUE"])
+            logger.info(f"MIN_FLUXMAG_QUEUE is set to {min_fluxmag_queue}")
         except ValueError:
-            logger.warning(f"Invalid MIN_FLUXMAG value: {config['MIN_FLUXMAG']}")
-    if "MAX_FLUXMAG" in config.keys() and config["MAX_FLUXMAG"] != "":
+            logger.warning(f"Invalid MIN_FLUXMAG_QUEUE value: {config['MIN_FLUXMAG_QUEUE']}")
+
+    min_fluxmag_classical = None
+    if "MIN_FLUXMAG_CLASSICAL" in config.keys() and config["MIN_FLUXMAG_CLASSICAL"] != "":
         try:
-            max_fluxmag = float(config["MAX_FLUXMAG"])
-            logger.info(f"MAX_FLUXMAG is set to {max_fluxmag}")
+            min_fluxmag_classical = float(config["MIN_FLUXMAG_CLASSICAL"])
+            logger.info(f"MIN_FLUXMAG_CLASSICAL is set to {min_fluxmag_classical}")
         except ValueError:
-            logger.warning(f"Invalid MAX_FLUXMAG value: {config['MAX_FLUXMAG']}")
-    # Load MIN_FLUXMAG_FILLER (optional, falls back to MIN_FLUXMAG)
+            logger.warning(f"Invalid MIN_FLUXMAG_CLASSICAL value: {config['MIN_FLUXMAG_CLASSICAL']}")
+
     min_fluxmag_filler = None
     if "MIN_FLUXMAG_FILLER" in config.keys() and config["MIN_FLUXMAG_FILLER"] != "":
         try:
@@ -129,6 +138,15 @@ def target_uploader_app(use_panel_cli=False):
             logger.info(f"MIN_FLUXMAG_FILLER is set to {min_fluxmag_filler}")
         except ValueError:
             logger.warning(f"Invalid MIN_FLUXMAG_FILLER value: {config['MIN_FLUXMAG_FILLER']}")
+
+    # Maximum flux magnitude (shared across all observation types)
+    max_fluxmag = None
+    if "MAX_FLUXMAG" in config.keys() and config["MAX_FLUXMAG"] != "":
+        try:
+            max_fluxmag = float(config["MAX_FLUXMAG"])
+            logger.info(f"MAX_FLUXMAG is set to {max_fluxmag}")
+        except ValueError:
+            logger.warning(f"Invalid MAX_FLUXMAG value: {config['MAX_FLUXMAG']}")
 
     logger.info(f"config params from dotenv: {config}")
 
@@ -371,7 +389,10 @@ def target_uploader_app(use_panel_cli=False):
 
         # Select min_mag based on observation type
         effective_min_mag = _get_min_fluxmag_for_obstype(
-            panel_obs_type.obs_type.value, min_fluxmag, min_fluxmag_filler
+            panel_obs_type.obs_type.value,
+            min_fluxmag_queue,
+            min_fluxmag_classical,
+            min_fluxmag_filler,
         )
 
         validation_status, df_input, df_validated = await asyncio.to_thread(
@@ -448,7 +469,10 @@ def target_uploader_app(use_panel_cli=False):
 
         # Select min_mag based on observation type
         effective_min_mag = _get_min_fluxmag_for_obstype(
-            panel_obs_type.obs_type.value, min_fluxmag, min_fluxmag_filler
+            panel_obs_type.obs_type.value,
+            min_fluxmag_queue,
+            min_fluxmag_classical,
+            min_fluxmag_filler,
         )
 
         validation_status, df_input_, df_validated = await asyncio.to_thread(
@@ -594,7 +618,10 @@ def target_uploader_app(use_panel_cli=False):
         # from callback to another function (sorry)
         # Select min_mag based on observation type
         effective_min_mag = _get_min_fluxmag_for_obstype(
-            panel_obs_type.obs_type.value, min_fluxmag, min_fluxmag_filler
+            panel_obs_type.obs_type.value,
+            min_fluxmag_queue,
+            min_fluxmag_classical,
+            min_fluxmag_filler,
         )
 
         validation_status, df_input, df_validated = await asyncio.to_thread(

--- a/src/pfs_target_uploader/utils/checker.py
+++ b/src/pfs_target_uploader/utils/checker.py
@@ -940,6 +940,156 @@ def check_fluxvalues(
     return dict_flux_values
 
 
+def check_fluxrange(
+    df: pd.DataFrame,
+    filter_category: dict = filter_category,
+    min_mag: float | None = None,
+    max_mag: float | None = None,
+    logger=logger,
+):
+    """
+    Check if flux values are within specified AB magnitude range.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Target dataframe with flux_{band} columns (values in nJy)
+    filter_category : dict
+        Dictionary of filter bands (default from __init__.py)
+    min_mag : float or None
+        Minimum AB magnitude (brightest allowed limit).
+        None means no bright limit.
+    max_mag : float or None
+        Maximum AB magnitude (faintest allowed limit).
+        None means no faint limit.
+    logger : loguru.Logger
+        Logger instance
+
+    Returns
+    -------
+    dict
+        Dictionary with validation results:
+        - status: bool (True if all in range, False if any out of range)
+        - min_mag, max_mag: input magnitude limits
+        - min_flux_nJy, max_flux_nJy: converted flux limits
+        - success_flux_{band}: per-row boolean arrays
+        - status_flux_{band}: per-band overall status
+        - num_total_flux_{band}, num_out_of_range_flux_{band}: counts
+        - success: overall per-row boolean array
+        - num_total_flux, num_out_of_range_flux: overall counts
+
+    Notes
+    -----
+    AB magnitude to nJy conversion uses astropy.units for accuracy.
+
+    A brighter magnitude (lower number) corresponds to higher flux in nJy.
+    Therefore:
+    - min_mag (bright limit) -> max_flux_nJy (upper flux bound)
+    - max_mag (faint limit) -> min_flux_nJy (lower flux bound)
+    """
+    bands = filter_category.keys()
+
+    # Convert AB magnitude limits to nJy using astropy.units
+    # Note: brighter mag (smaller number) = higher flux
+    min_flux_nJy = None
+    max_flux_nJy = None
+
+    if max_mag is not None:
+        # Faint limit -> lower flux bound
+        min_flux_nJy = (max_mag * u.ABmag).to_value(u.nJy)
+
+    if min_mag is not None:
+        # Bright limit -> upper flux bound
+        max_flux_nJy = (min_mag * u.ABmag).to_value(u.nJy)
+
+    dict_fluxval = {
+        "min_mag": min_mag,
+        "max_mag": max_mag,
+        "min_flux_nJy": min_flux_nJy,
+        "max_flux_nJy": max_flux_nJy,
+    }
+
+    # Track overall success per row
+    success_all = np.ones(df.index.size, dtype=bool)
+    num_total_flux = 0
+    num_out_of_range_flux = 0
+
+    for band in bands:
+        col_name = f"flux_{band}"
+        if col_name not in df.columns:
+            continue
+
+        is_flux_finite = np.isfinite(df[col_name])
+        num_total = np.sum(is_flux_finite)
+
+        # Initialize per-row success as True for finite values
+        is_in_range = is_flux_finite.copy()
+
+        # Apply lower bound (faint limit)
+        if min_flux_nJy is not None:
+            is_in_range = is_in_range & (
+                (df[col_name] >= min_flux_nJy) | ~is_flux_finite
+            )
+
+        # Apply upper bound (bright limit)
+        if max_flux_nJy is not None:
+            is_in_range = is_in_range & (
+                (df[col_name] <= max_flux_nJy) | ~is_flux_finite
+            )
+
+        # For non-finite values, mark as True (not checked)
+        is_in_range = is_in_range | ~is_flux_finite
+
+        num_out_of_range = np.sum(is_flux_finite & ~is_in_range)
+        status_band = num_out_of_range == 0
+
+        dict_fluxval[f"success_flux_{band}"] = is_in_range
+        dict_fluxval[f"status_flux_{band}"] = status_band
+        dict_fluxval[f"num_total_flux_{band}"] = int(num_total)
+        dict_fluxval[f"num_out_of_range_flux_{band}"] = int(num_out_of_range)
+
+        # Update overall tracking
+        success_all = success_all & is_in_range
+        num_total_flux += num_total
+        num_out_of_range_flux += num_out_of_range
+
+        # Log results for each band
+        if num_total > 0:
+            if status_band:
+                logger.info(
+                    f"[Flux {band}] All {num_total} values within magnitude range - OK"
+                )
+            else:
+                logger.warning(
+                    f"[Flux {band}] {num_out_of_range}/{num_total} values out of range "
+                    f"(AB mag {min_mag} to {max_mag}) - WARNING"
+                )
+
+    # Overall status
+    status_overall = num_out_of_range_flux == 0
+    dict_fluxval["status"] = status_overall
+    dict_fluxval["success"] = success_all
+    dict_fluxval["num_total_flux"] = int(num_total_flux)
+    dict_fluxval["num_out_of_range_flux"] = int(num_out_of_range_flux)
+
+    # Log overall summary
+    if num_total_flux > 0:
+        if status_overall:
+            logger.info(
+                f"[Flux range check] All {num_total_flux} flux values within "
+                f"AB magnitude range [{min_mag}, {max_mag}] - OK"
+            )
+        else:
+            logger.warning(
+                f"[Flux range check] {num_out_of_range_flux}/{num_total_flux} flux values "
+                f"out of AB magnitude range [{min_mag}, {max_mag}] - WARNING"
+            )
+    else:
+        logger.warning("[Flux range check] No flux values found to check")
+
+    return dict_fluxval
+
+
 def check_visibility(
     df,
     date_begin=None,
@@ -1153,6 +1303,8 @@ def validate_input(
     single_exptime=900,
     healpix=True,
     nside=32,
+    min_mag=None,
+    max_mag=None,
     logger=logger,
 ):
     logger.info("Validation of the input list starts")
@@ -1177,6 +1329,7 @@ def validate_input(
     validation_status["values"] = {"status": None}
     validation_status["flux_columns"] = {"status": None}
     validation_status["flux_values"] = {"status": None}
+    validation_status["flux_range"] = {"status": None}
     validation_status["visibility"] = {"status": None}
     validation_status["unique"] = {"status": None}
 
@@ -1226,6 +1379,22 @@ def validate_input(
     dict_flux_values = check_fluxvalues(df)
     validation_status["flux_values"] = dict_flux_values
     logger.info(f"[Flux values] status: {dict_flux_values['status']} (Success if True)")
+
+    # check flux value range (AB magnitude based)
+    if min_mag is not None or max_mag is not None:
+        logger.info("[Flux range] Checking flux values against AB magnitude range")
+        dict_flux_range = check_fluxrange(df, min_mag=min_mag, max_mag=max_mag)
+        validation_status["flux_range"] = dict_flux_range
+        logger.info(f"[Flux range] status: {dict_flux_range['status']} (Success if True)")
+    else:
+        logger.info("[Flux range] Skipping flux range check (no limits specified)")
+        validation_status["flux_range"] = {
+            "status": True,
+            "min_mag": None,
+            "max_mag": None,
+            "min_flux_nJy": None,
+            "max_flux_nJy": None,
+        }
 
     # check columns for visibility
     logger.info("[Visibility] Checking target visibility")

--- a/src/pfs_target_uploader/utils/checker.py
+++ b/src/pfs_target_uploader/utils/checker.py
@@ -1397,7 +1397,7 @@ def validate_input(
     else:
         logger.info("[Flux range] Skipping flux range check (no limits specified)")
         validation_status["flux_range"] = {
-            "status": True,
+            "status": None,
             "min_mag": None,
             "max_mag": None,
             "min_flux_nJy": None,

--- a/src/pfs_target_uploader/utils/checker.py
+++ b/src/pfs_target_uploader/utils/checker.py
@@ -989,6 +989,14 @@ def check_fluxrange(
     """
     bands = filter_category.keys()
 
+    # Validate magnitude range consistency
+    if min_mag is not None and max_mag is not None:
+        if min_mag > max_mag:
+            raise ValueError(
+                f"Invalid magnitude range: min_mag ({min_mag}) > max_mag ({max_mag}). "
+                f"min_mag should be brighter (smaller value) than max_mag."
+            )
+
     # Convert AB magnitude limits to nJy using astropy.units
     # Note: brighter mag (smaller number) = higher flux
     min_flux_nJy = None

--- a/src/pfs_target_uploader/utils/checker.py
+++ b/src/pfs_target_uploader/utils/checker.py
@@ -1394,6 +1394,9 @@ def validate_input(
             "max_mag": None,
             "min_flux_nJy": None,
             "max_flux_nJy": None,
+            "success": np.ones(len(df), dtype=bool),
+            "num_total_flux": 0,
+            "num_out_of_range_flux": 0,
         }
 
     # check columns for visibility

--- a/src/pfs_target_uploader/widgets/FileInputWidgets.py
+++ b/src/pfs_target_uploader/widgets/FileInputWidgets.py
@@ -70,6 +70,8 @@ class FileInputWidgets(param.Parameterized):
         date_begin=None,
         date_end=None,
         single_exptime=900.0,
+        min_mag=None,
+        max_mag=None,
         warn_threshold=100000,
     ):
         t_start = time.time()
@@ -139,6 +141,8 @@ class FileInputWidgets(param.Parameterized):
             date_begin=date_begin,
             date_end=date_end,
             single_exptime=single_exptime,
+            min_mag=min_mag,
+            max_mag=max_mag,
         )
         t_stop = time.time()
         logger.info(f"Validation finished in {t_stop - t_start:.2f} [s]")

--- a/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
+++ b/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
@@ -431,7 +431,6 @@ class ValidationResultWidgets:
         ):
             if validation_status["flux_range"]["status"]:
                 # Success case: all flux values within range
-                # Note: info_text_flux is already appended to info_pane, just add to existing text
                 min_mag = validation_status["flux_range"]["min_mag"]
                 max_mag = validation_status["flux_range"]["max_mag"]
 
@@ -444,6 +443,11 @@ class ValidationResultWidgets:
                     range_desc = f"not fainter than AB magnitude {max_mag}"
                 else:
                     range_desc = "within expected range"
+
+                # Ensure info_text_flux is in info_pane before appending
+                if self.info_text_flux not in self.info_pane:
+                    self.append_title("info")
+                    self.info_pane.append(self.info_text_flux)
 
                 self.info_text_flux.object += (
                     f"\n\n<font size=3>All flux values are {range_desc}.</font>"

--- a/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
+++ b/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
@@ -407,7 +407,13 @@ class ValidationResultWidgets:
 
         # Flux values
         if validation_status["flux_values"]["status"]:
-            # Note: info_text_flux is already appended to info_pane in flux_columns section
+            # Ensure info_text_flux is visible in the info pane before appending text
+            if self.info_text_flux not in self.info_pane:
+                self.append_title("info")
+                # Provide a basic header if none was set by the flux-columns section
+                if not getattr(self.info_text_flux, "object", None):
+                    self.info_text_flux.object = "<font size=4><u>Flux information</u></font>"
+                self.info_pane.append(self.info_text_flux)
             self.info_text_flux.object += "\n\n<font size=3>Flux values can be regarded as properly provided with the unit of nano Jansky (nJy).</font>"
         else:
             self.append_title("warning")

--- a/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
+++ b/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import panel as pn
+from astropy import units as u
 
 
 class ValidationResultWidgets:
@@ -75,6 +76,7 @@ class ValidationResultWidgets:
         self.warning_text_str = pn.pane.Markdown("", max_width=self.box_width)
         self.warning_text_vals = pn.pane.Markdown("", max_width=self.box_width)
         self.warning_text_flux = pn.pane.Markdown("", max_width=self.box_width)
+        self.warning_text_fluxrange = pn.pane.Markdown("", max_width=self.box_width)
         self.warning_text_visibility = pn.pane.Markdown("", max_width=self.box_width)
         self.warning_text_intdups = pn.pane.Markdown("", max_width=self.box_width)
 
@@ -101,6 +103,10 @@ class ValidationResultWidgets:
         )
 
         self.error_table_flux = pn.widgets.Tabulator(
+            pd.DataFrame(), **self.tabulator_kwargs
+        )
+
+        self.warning_table_fluxrange = pn.widgets.Tabulator(
             pd.DataFrame(), **self.tabulator_kwargs
         )
 
@@ -147,6 +153,7 @@ class ValidationResultWidgets:
             self.warning_text_str,
             self.warning_text_vals,
             self.warning_text_flux,
+            self.warning_text_fluxrange,
             self.warning_text_visibility,
             self.warning_text_intdups,
             self.info_text_keys,
@@ -165,6 +172,7 @@ class ValidationResultWidgets:
             self.error_table_vals,
             self.warning_table_vals,
             self.error_table_flux,
+            self.warning_table_fluxrange,
             self.error_table_visibility,
             self.warning_table_visibility,
             self.error_table_dups,
@@ -198,6 +206,48 @@ class ValidationResultWidgets:
                 self.info_pane.append(self.info_title)
                 self.is_info = True
                 self.info_title.visible = True
+
+    def _identify_out_of_range_bands(self, df, min_flux_nJy, max_flux_nJy):
+        """
+        Identify which flux bands are out of range for each row (vectorized).
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            DataFrame with flux columns
+        min_flux_nJy : float or None
+            Minimum flux in nJy (lower bound)
+        max_flux_nJy : float or None
+            Maximum flux in nJy (upper bound)
+
+        Returns
+        -------
+        dict
+            Dictionary mapping row index to list of out-of-range bands
+        """
+        out_of_range_bands = {idx: [] for idx in df.index}
+
+        for band in ["g", "r", "i", "z", "y", "j"]:
+            flux_col = f"flux_{band}"
+            if flux_col not in df.columns:
+                continue
+
+            # Vectorized check
+            flux_vals = df[flux_col]
+            is_finite = np.isfinite(flux_vals)
+            is_out = np.zeros(len(flux_vals), dtype=bool)
+
+            if min_flux_nJy is not None:
+                is_out |= (flux_vals < min_flux_nJy) & is_finite
+            if max_flux_nJy is not None:
+                is_out |= (flux_vals > max_flux_nJy) & is_finite
+
+            # Store band name for out-of-range rows
+            out_indices = df.index[is_out]
+            for idx in out_indices:
+                out_of_range_bands[idx].append(band)
+
+        return out_of_range_bands
 
     def show_results(self, df, validation_status):
         # reset title panes
@@ -357,10 +407,8 @@ class ValidationResultWidgets:
 
         # Flux values
         if validation_status["flux_values"]["status"]:
-            self.append_title("info")
-
+            # Note: info_text_flux is already appended to info_pane in flux_columns section
             self.info_text_flux.object += "\n\n<font size=3>Flux values can be regarded as properly provided with the unit of nano Jansky (nJy).</font>"
-            self.info_pane.append(self.info_text_flux)
         else:
             self.append_title("warning")
             self.warning_text_flux.object = (
@@ -375,6 +423,141 @@ class ValidationResultWidgets:
             )
 
             self.warning_pane.append(self.warning_text_flux)
+
+        # Flux range (AB magnitude based)
+        if (
+            "flux_range" in validation_status
+            and validation_status["flux_range"]["status"] is not None
+        ):
+            if validation_status["flux_range"]["status"]:
+                # Success case: all flux values within range
+                # Note: info_text_flux is already appended to info_pane, just add to existing text
+                min_mag = validation_status["flux_range"]["min_mag"]
+                max_mag = validation_status["flux_range"]["max_mag"]
+
+                # Create range description
+                if min_mag is not None and max_mag is not None:
+                    range_desc = f"AB magnitude range [{min_mag}, {max_mag}]"
+                elif min_mag is not None:
+                    range_desc = f"not brighter than AB magnitude {min_mag}"
+                elif max_mag is not None:
+                    range_desc = f"not fainter than AB magnitude {max_mag}"
+                else:
+                    range_desc = "within expected range"
+
+                self.info_text_flux.object += (
+                    f"\n\n<font size=3>All flux values are {range_desc}.</font>"
+                )
+            else:
+                self.append_title("warning")
+                min_mag = validation_status["flux_range"]["min_mag"]
+                max_mag = validation_status["flux_range"]["max_mag"]
+                num_out = validation_status["flux_range"]["num_out_of_range_flux"]
+                num_total = validation_status["flux_range"]["num_total_flux"]
+
+                # Create range description
+                if min_mag is not None and max_mag is not None:
+                    range_desc = f"AB magnitude range [{min_mag}, {max_mag}]"
+                elif min_mag is not None:
+                    range_desc = f"brighter than AB magnitude {min_mag}"
+                elif max_mag is not None:
+                    range_desc = f"fainter than AB magnitude {max_mag}"
+                else:
+                    range_desc = "specified range"
+
+                self.warning_text_fluxrange.object = "<font size=4><u>Flux values out of AB magnitude range</u></font>\n\n"
+                self.warning_text_fluxrange.object += (
+                    f"<font size=3>{num_out}/{num_total} flux values are {range_desc}. "
+                    "Please verify that these targets are intended to be outside this range.</font>"
+                )
+
+                # Show table of out-of-range targets with flux and magnitude columns
+                success_all = validation_status["flux_range"]["success"]
+                df_out_of_range = df.loc[~success_all, :].copy()
+
+                # Get flux limits for identifying out-of-range bands
+                min_flux_nJy = validation_status["flux_range"]["min_flux_nJy"]
+                max_flux_nJy = validation_status["flux_range"]["max_flux_nJy"]
+
+                # Identify which bands are out of range for each row
+                out_of_range_bands = self._identify_out_of_range_bands(
+                    df_out_of_range, min_flux_nJy, max_flux_nJy
+                )
+
+                # Add magnitude columns for each flux band
+                for band in ["g", "r", "i", "z", "y", "j"]:
+                    flux_col = f"flux_{band}"
+                    mag_col = f"mag_{band}"
+                    if flux_col in df_out_of_range.columns:
+                        # Convert flux (nJy) to AB magnitude
+                        flux_vals = df_out_of_range[flux_col].values
+                        mag_vals = np.full_like(flux_vals, np.nan, dtype=float)
+                        finite_mask = np.isfinite(flux_vals) & (flux_vals > 0)
+                        if np.any(finite_mask):
+                            mag_vals[finite_mask] = (
+                                flux_vals[finite_mask] * u.nJy
+                            ).to_value(u.ABmag)
+                        df_out_of_range[mag_col] = mag_vals
+
+                # Select columns to display
+                base_cols = ["ob_code", "obj_id_str", "ra", "dec"]
+                flux_mag_cols = []
+                for band in ["g", "r", "i", "z", "y", "j"]:
+                    flux_col = f"flux_{band}"
+                    filter_col = f"filter_{band}"
+                    mag_col = f"mag_{band}"
+                    if flux_col in df_out_of_range.columns:
+                        if filter_col in df_out_of_range.columns:
+                            flux_mag_cols.extend([filter_col, flux_col, mag_col])
+                        else:
+                            flux_mag_cols.extend([flux_col, mag_col])
+
+                display_cols = base_cols + flux_mag_cols
+                available_cols = [
+                    col for col in display_cols if col in df_out_of_range.columns
+                ]
+
+                # Format flux and mag columns to 2 decimal places
+                df_display = df_out_of_range[available_cols].copy()
+
+                # Format all flux and mag columns to 2 decimal places
+                for band in ["g", "r", "i", "z", "y", "j"]:
+                    flux_col = f"flux_{band}"
+                    mag_col = f"mag_{band}"
+                    if flux_col in available_cols:
+                        df_display[flux_col] = df_display[flux_col].apply(
+                            lambda x: f"{x:.2f}" if pd.notna(x) else x
+                        )
+                    if mag_col in available_cols:
+                        df_display[mag_col] = df_display[mag_col].apply(
+                            lambda x: f"{x:.2f}" if pd.notna(x) else x
+                        )
+
+                # Mark out-of-range cells with a warning symbol
+                for row_idx, bands in out_of_range_bands.items():
+                    if bands:  # Only if there are out-of-range bands
+                        for band in bands:
+                            flux_col = f"flux_{band}"
+                            filter_col = f"filter_{band}"
+                            mag_col = f"mag_{band}"
+
+                            # Add warning symbol to out-of-range values
+                            if flux_col in available_cols and pd.notna(df_display.at[row_idx, flux_col]):
+                                df_display.at[row_idx, flux_col] = f"⚠ {df_display.at[row_idx, flux_col]}"
+                            if mag_col in available_cols and pd.notna(df_display.at[row_idx, mag_col]):
+                                df_display.at[row_idx, mag_col] = f"⚠ {df_display.at[row_idx, mag_col]}"
+                            if filter_col in available_cols and pd.notna(df_display.at[row_idx, filter_col]):
+                                df_display.at[row_idx, filter_col] = f"⚠ {df_display.at[row_idx, filter_col]}"
+
+                self.warning_table_fluxrange.frozen_columns = []
+                if self.warning_table_fluxrange.value is not None:
+                    self.warning_table_fluxrange.value[0:0]
+
+                self.warning_table_fluxrange.value = df_display
+                self.warning_table_fluxrange.frozen_columns = ["index"]
+                self.warning_pane.append(self.warning_text_fluxrange)
+                self.warning_pane.append(self.warning_table_fluxrange)
+                self.warning_table_fluxrange.visible = True
 
         # Visibility
         # TODO: add begin_date and end_date in the message


### PR DESCRIPTION
## Summary

Implements flux range validation to check whether target flux values fall within user-specified AB magnitude ranges. This helps identify targets that may be too bright or too faint for PFS observations.

**Latest update:** Separated minimum flux magnitude settings by observation mode for more flexible validation.

## Changes

### Core Validation Logic
- Added `check_fluxrange()` function in `checker.py` for AB magnitude-based flux validation
- Integrated into `validate_input()` pipeline with proper status tracking
- Uses `astropy.units` for accurate AB magnitude ↔ nJy conversion
- Returns warnings (not errors) to allow submission after user verification

### Configuration - Observation Mode Specific Settings
- **New**: Separate minimum magnitude settings for each observation mode:
  - `MIN_FLUXMAG_QUEUE` - Bright limit for queue observation type
  - `MIN_FLUXMAG_CLASSICAL` - Bright limit for classical observation type
  - `MIN_FLUXMAG_FILLER` - Bright limit for filler observation type
- `MAX_FLUXMAG` - Faint limit (shared across all observation types)
- All settings are optional and can be left empty to disable range checking

### Web App Integration
- Configuration values read from `.env.shared` in `pn_app.py`
- `_get_min_fluxmag_for_obstype()` function selects appropriate min_mag based on selected observation mode
- Automatically applies correct limits when user changes observation type in UI
- Logs the applied limits for transparency

### CLI Simplification
- CLI commands use `--obs-type` to specify observation mode
- Simple `--min-mag` and `--max-mag` options (no mode-specific options)
- User sets the appropriate value for their chosen observation type
- Example: `pfs-uploader-cli validate list.csv --obs-type queue --min-mag 10.0 --max-mag 30.0`

### UI Display
- Enhanced `ValidationResultWidgets` to display flux range warnings
- Added `_identify_out_of_range_bands()` helper for vectorized band detection
- Shows Tabulator table with: `obj_id_str`, coordinates, filter, flux, and magnitude
- Out-of-range values marked with ⚠ symbol
- All flux/magnitude values formatted to 2 decimal places
- Success message shown in Info section when all values within range

### Documentation Updates
- Updated `.env.shared.example` with new settings and examples
- Updated `README.md` with configuration examples
- Updated `CLAUDE.md` with implementation details

### Bug Fixes
- Fixed KeyError when both `min_mag` and `max_mag` are None by ensuring validation_status dict always contains required keys

## Technical Details

**AB Magnitude Conversion:**
- Brighter magnitude (lower number) = higher flux in nJy
- `min_mag` (bright limit) → `max_flux_nJy` (upper bound)
- `max_mag` (faint limit) → `min_flux_nJy` (lower bound)

**Observation Mode Logic:**
- Queue: uses `MIN_FLUXMAG_QUEUE`
- Classical: uses `MIN_FLUXMAG_CLASSICAL`
- Filler: uses `MIN_FLUXMAG_FILLER`
- Returns `None` if the corresponding setting is not configured

**Performance:**
- Vectorized NumPy operations for range checking
- Per-band and overall status tracking
- Efficient detection of out-of-range bands

## Usage Examples

### Web App Configuration (.env.shared)
```bash
# Observation mode specific bright limits
MIN_FLUXMAG_QUEUE=10.0      # For queue observations
MIN_FLUXMAG_CLASSICAL=12.0  # For classical observations
MIN_FLUXMAG_FILLER=15.0     # For filler observations

# Shared faint limit
MAX_FLUXMAG=30.0            # Same for all observation types
```

### CLI Usage
```bash
# Queue observations
pfs-uploader-cli validate target_list.csv --obs-type queue --min-mag 10.0 --max-mag 30.0

# Classical observations
pfs-uploader-cli validate target_list.csv --obs-type classical --min-mag 12.0 --max-mag 30.0

# Filler observations
pfs-uploader-cli validate target_list.csv --obs-type filler --min-mag 15.0 --max-mag 30.0
```

## Test Plan

- [x] Test with all mode-specific limits set
- [x] Test with only some limits set (partial configuration)
- [x] Test with no limits set (should skip validation gracefully)
- [x] Verify web app applies correct limit when switching observation modes
- [x] Verify warning display shows correct out-of-range targets
- [x] Verify CLI commands work with --obs-type and --min-mag/--max-mag
- [x] Verify ⚠ symbol appears on out-of-range values in Tabulator
- [x] Verify success message appears when all values in range
- [x] Verify backwards compatibility (old configs without new settings)
- [x] Test all three observation modes (queue, classical, filler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)