### PR TITLE
Update flux validation documentation and add PFS observations links

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,7 +4,7 @@ The [PFS Target Uploader](https://pfs-etc.naoj.hawaii.edu/uploader/) is a web ap
 supplied by users with an observing time estimate by a pointing simulation.
 
 !!! info
-    **August 10, 2024 (HST)**
+**August 10, 2024 (HST)**
 
     In the examples of [input target lists](inputs.md), column names for fluxes are found to be incorrect
     for the initial version released together with S25A CfP on August 5, 2024 (HST).
@@ -16,41 +16,41 @@ supplied by users with an observing time estimate by a pointing simulation.
 
 <div class="grid cards" markdown>
 
-- :material-list-box-outline:{ .lg .middle } [__Prepare Your Target List__](inputs.md)
+- :material-list-box-outline:{ .lg .middle } [**Prepare Your Target List**](inputs.md)
 
-    ---
+  ***
 
-    Understand the file format and contents of your input target list required for PFS observation.
+  Understand the file format and contents of your input target list required for PFS observation.
 
-- :material-stethoscope:{ .lg .middle } [__Validate Your Target List__](validation.md)
+- :material-stethoscope:{ .lg .middle } [**Validate Your Target List**](validation.md)
 
-    ---
+  ***
 
-    Check if your input target list meets the requirements and understand errors and warnings.
+  Check if your input target list meets the requirements and understand errors and warnings.
 
-- :material-calculator:{ .lg .middle } [__Simulate PFS Pointings__](PPP.md)
+- :material-calculator:{ .lg .middle } [**Simulate PFS Pointings**](PPP.md)
 
-    ---
+  ***
 
-    Estimate required observing time to complete your targets by using the PFS pointing planner.
+  Estimate required observing time to complete your targets by using the PFS pointing planner.
 
-- :material-file-send-outline:{ .lg .middle } [__Submit Your Targets__](submission.md)
+- :material-file-send-outline:{ .lg .middle } [**Submit Your Targets**](submission.md)
 
-    ---
+  ***
 
-    Submit the target list and receive a `Upload ID`.
+  Submit the target list and receive a `Upload ID`.
 
-- :material-chat-question-outline:{ .lg .middle } [__FAQ & Known Issues__](issues.md)
+- :material-chat-question-outline:{ .lg .middle } [**FAQ & Known Issues**](issues.md)
 
-    ---
+  ***
 
-    Check frequently asked questions and known issues first when you have any troubles with the app.
+  Check frequently asked questions and known issues first when you have any troubles with the app.
 
-- :material-account-box-outline:{ .lg .middle } [__About Us__](about.md)
+- :material-account-box-outline:{ .lg .middle } [**About Us**](about.md)
 
-    ---
+  ***
 
-    Contact information and the privacy policy of the app and documationation are available.
+  Contact information and the privacy policy of the app and documationation are available.
 
 </div>
 
@@ -96,6 +96,6 @@ graph TD
 
 ## Last Update
 
-August 10, 2024 (HST)
+January, 2026 (HST)
 
 See the [Releases on GitHub repository](https://github.com/Subaru-PFS/spt_target_uploader/releases) for the details.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -7,13 +7,13 @@ supplied by users with an observing time estimate by a pointing simulation.
 
     **January 26, 2026 (HST)**
 
-    Update for S26B Call for Proposals on Subaru Telescope includes the following changes:
+    Updates for S26B Call for Proposals include the following changes:
 
     - The last 7 characters of the `Upload ID` are appended to `ob_code` automatically when the target list is loaded.
     - Flux values are checked against the bright magnitude limits.
     - Flux values are checked to detect potential unit mismatches.
-    - Target duplication within the target list is added to remind users to verify their target list.
-    - Pointing simulations is updated to use a realistic focal plane configuration.
+    - Target duplication checking within the target list has been added to remind users to verify their target list.
+    - Pointing simulations are updated to use a realistic focal plane configuration.
 
 ## Table of Contents
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -14,45 +14,51 @@ supplied by users with an observing time estimate by a pointing simulation.
 
 ## Table of Contents
 
+<!-- markdownlint-disable -->
+<!-- prettier-ignore-start -->
+
 <div class="grid cards" markdown>
 
-- :material-list-box-outline:{ .lg .middle } [**Prepare Your Target List**](inputs.md)
+- :material-list-box-outline:{ .lg .middle } [__Prepare Your Target List__](inputs.md)
 
-  ***
+    ---
 
-  Understand the file format and contents of your input target list required for PFS observation.
+    Understand the file format and contents of your input target list required for PFS observation.
 
-- :material-stethoscope:{ .lg .middle } [**Validate Your Target List**](validation.md)
+- :material-stethoscope:{ .lg .middle } [__Validate Your Target List__](validation.md)
 
-  ***
+    ---
 
-  Check if your input target list meets the requirements and understand errors and warnings.
+    Check if your input target list meets the requirements and understand errors and warnings.
 
-- :material-calculator:{ .lg .middle } [**Simulate PFS Pointings**](PPP.md)
+- :material-calculator:{ .lg .middle } [__Simulate PFS Pointings__](PPP.md)
 
-  ***
+    ---
 
-  Estimate required observing time to complete your targets by using the PFS pointing planner.
+    Estimate required observing time to complete your targets by using the PFS pointing planner.
 
-- :material-file-send-outline:{ .lg .middle } [**Submit Your Targets**](submission.md)
+- :material-file-send-outline:{ .lg .middle } [__Submit Your Targets__](submission.md)
 
-  ***
+    ---
 
-  Submit the target list and receive a `Upload ID`.
+    Submit the target list and receive a `Upload ID`.
 
-- :material-chat-question-outline:{ .lg .middle } [**FAQ & Known Issues**](issues.md)
+- :material-chat-question-outline:{ .lg .middle } [__FAQ & Known Issues__](issues.md)
 
-  ***
+    ---
 
-  Check frequently asked questions and known issues first when you have any troubles with the app.
+    Check frequently asked questions and known issues first when you have any troubles with the app.
 
-- :material-account-box-outline:{ .lg .middle } [**About Us**](about.md)
+- :material-account-box-outline:{ .lg .middle } [__About Us__](about.md)
 
-  ***
+    ---
 
-  Contact information and the privacy policy of the app and documationation are available.
+    Contact information and the privacy policy of the app and documationation are available.
 
 </div>
+
+<!-- markdownlint-enable -->
+<!-- prettier-ignore-end -->
 
 ## Workflow
 
@@ -96,6 +102,6 @@ graph TD
 
 ## Last Update
 
-January, 2026 (HST)
+August 10, 2024 (HST)
 
 See the [Releases on GitHub repository](https://github.com/Subaru-PFS/spt_target_uploader/releases) for the details.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,13 +4,16 @@ The [PFS Target Uploader](https://pfs-etc.naoj.hawaii.edu/uploader/) is a web ap
 supplied by users with an observing time estimate by a pointing simulation.
 
 !!! info
-**August 10, 2024 (HST)**
 
-    In the examples of [input target lists](inputs.md), column names for fluxes are found to be incorrect
-    for the initial version released together with S25A CfP on August 5, 2024 (HST).
-    The `r`- (`i`-) band filters for HSC need to be either `r_old_hsc` or `r2_hsc` (`i_old_hsc` or `i2_hsc`).
-    We have updated the examples with correct information for the correct examples.
-    Please see the [Filters section](inputs.md#filters) for the details.
+    **January 26, 2026 (HST)**
+
+    Update for S26B Call for Proposals on Subaru Telescope includes the following changes:
+
+    - The last 7 characters of the `Upload ID` are appended to `ob_code` automatically when the target list is loaded.
+    - Flux values are checked against the bright magnitude limits.
+    - Flux values are checked to detect potential unit mismatches.
+    - Target duplication within the target list is added to remind users to verify their target list.
+    - Pointing simulations is updated to use a realistic focal plane configuration.
 
 ## Table of Contents
 
@@ -100,8 +103,6 @@ graph TD
 
 ![type:video](videos/demo_v2.mp4){: style='width: 100%'}
 
-## Last Update
+## Release Notes
 
-August 10, 2024 (HST)
-
-See the [Releases on GitHub repository](https://github.com/Subaru-PFS/spt_target_uploader/releases) for the details.
+See the [Releases on GitHub repository](https://github.com/Subaru-PFS/spt_target_uploader/releases) for the latest updates and changes.

--- a/docs/docs/inputs.md
+++ b/docs/docs/inputs.md
@@ -116,8 +116,18 @@ Flux columns must conform to the following requirements.
 - Flux values are in the unit of <font size=5>**nJy**</font> (nano-Jansky).
 - Flux values are assumed to be total flux.
 - Flux errors can be provided by using column names by adding `_error` following the filter names.
-- All **queue-mode** targets must be fainter than **16 AB mag** in all provided filters.
-- All **filler-mode** targets must be fainter than **17 AB mag** in all provided filters.
+- All **queue-mode** targets are required to be fainter than **16 AB mag** in all provided filters.
+- All **filler-mode** targets are required to be fainter than **17 AB mag** in all provided filters.
+
+!!! note
+
+    The bright magnitude limits above are applied to avoid detector saturation and
+    to reduce near infrared persistency effects.
+    Users can still submit targets brighter than these limits,
+    but additional validation and checks will be performed
+    at the time of fiber assignment processing.
+    See the [Observation](https://www.naoj.org/Instruments/PFS/observations.html)
+    page of the PFS web site for details.
 
 ##### Example of flux information
 

--- a/docs/docs/validation.md
+++ b/docs/docs/validation.md
@@ -97,7 +97,7 @@ Flux values are checked to identify potential unit errors (magnitude vs. nano-Ja
 ### Flux range
 
 Flux values are additionally checked against flux/magnitude limits to identify targets that may be too bright or too faint for observations.
-The current bright magnitude limit is set to **16 AB mag for queue-mode** targets and **17 AB mag for filler-mode** targets in all provided filters.
+The current bright magnitude limits are set to **16 AB mag for queue-mode** targets and **17 AB mag for filler-mode** targets in all provided filters.
 
 !!! warning "Warning message is raised as follows"
 
@@ -109,7 +109,10 @@ The current bright magnitude limit is set to **16 AB mag for queue-mode** target
 
 !!! note "This is a warning-only check"
 
-    This validation does not prevent submission. It serves as a reminder to verify that targets outside the specified magnitude range are intentional. However, targets with flux values outside the specified range may be removed during the observation planning process.
+    This validation does not prevent submission.
+    It serves as a reminder to verify that targets outside the specified magnitude range are intentional.
+    However, targets with flux values outside the specified range may be removed during the observation planning process.
+    See the [Observation](https://www.naoj.org/Instruments/PFS/observations.html) page of the PFS web site for details.
 
 ### Target visibility
 

--- a/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
+++ b/src/pfs_target_uploader/widgets/ValidationResultWidgets.py
@@ -412,7 +412,9 @@ class ValidationResultWidgets:
                 self.append_title("info")
                 # Provide a basic header if none was set by the flux-columns section
                 if not getattr(self.info_text_flux, "object", None):
-                    self.info_text_flux.object = "<font size=4><u>Flux information</u></font>"
+                    self.info_text_flux.object = (
+                        "<font size=4><u>Flux information</u></font>"
+                    )
                 self.info_pane.append(self.info_text_flux)
             self.info_text_flux.object += "\n\n<font size=3>Flux values can be regarded as properly provided with the unit of nano Jansky (nJy).</font>"
         else:
@@ -478,7 +480,8 @@ class ValidationResultWidgets:
                 self.warning_text_fluxrange.object = "<font size=4><u>Flux values out of AB magnitude range</u></font>\n\n"
                 self.warning_text_fluxrange.object += (
                     f"<font size=3>{num_out}/{num_total} flux values are {range_desc}. "
-                    "Please verify that these targets are intended to be outside this range.</font>"
+                    "Please verify that these targets are intended to be outside this range. "
+                    "See the <a href='https://www.naoj.org/Instruments/PFS/observations.html' target='_blank'>Observations</a> section of the PFS instrument documentation for more details.</font>"
                 )
 
                 # Show table of out-of-range targets with flux and magnitude columns
@@ -552,12 +555,24 @@ class ValidationResultWidgets:
                             mag_col = f"mag_{band}"
 
                             # Add warning symbol to out-of-range values
-                            if flux_col in available_cols and pd.notna(df_display.at[row_idx, flux_col]):
-                                df_display.at[row_idx, flux_col] = f"⚠ {df_display.at[row_idx, flux_col]}"
-                            if mag_col in available_cols and pd.notna(df_display.at[row_idx, mag_col]):
-                                df_display.at[row_idx, mag_col] = f"⚠ {df_display.at[row_idx, mag_col]}"
-                            if filter_col in available_cols and pd.notna(df_display.at[row_idx, filter_col]):
-                                df_display.at[row_idx, filter_col] = f"⚠ {df_display.at[row_idx, filter_col]}"
+                            if flux_col in available_cols and pd.notna(
+                                df_display.at[row_idx, flux_col]
+                            ):
+                                df_display.at[row_idx, flux_col] = (
+                                    f"⚠ {df_display.at[row_idx, flux_col]}"
+                                )
+                            if mag_col in available_cols and pd.notna(
+                                df_display.at[row_idx, mag_col]
+                            ):
+                                df_display.at[row_idx, mag_col] = (
+                                    f"⚠ {df_display.at[row_idx, mag_col]}"
+                                )
+                            if filter_col in available_cols and pd.notna(
+                                df_display.at[row_idx, filter_col]
+                            ):
+                                df_display.at[row_idx, filter_col] = (
+                                    f"⚠ {df_display.at[row_idx, filter_col]}"
+                                )
 
                 self.warning_table_fluxrange.frozen_columns = []
                 if self.warning_table_fluxrange.value is not None:


### PR DESCRIPTION
## Summary

- Clarified that bright magnitude limits (16 AB mag for queue-mode, 17 AB mag for filler-mode) are requirements
- Added explanatory notes about additional validation during fiber assignment processing
- Added links to PFS observations page for users to get detailed information
- Improved code formatting in ValidationResultWidgets.py

## Test plan

- [x] Review documentation changes in inputs.md for clarity
- [x] Review documentation changes in validation.md for accuracy
- [x] Verify external link to PFS observations page works correctly
- [x] Test validation result widget displays warning messages properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)